### PR TITLE
refactor: clean architecture pass — split modules, fix pointer hazard…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y meson ninja-build libglfw3-dev libgl-dev
+          sudo apt-get install -y meson ninja-build libglfw3-dev libgl-dev libpng-dev
 
       - name: Configure
         run: meson setup builddir --buildtype=debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Claude Code guidelines for hpgl-viewer
+
+## Documentation
+
+Whenever new functionality is added — new UI controls, keyboard shortcuts, CLI flags, file formats, or behaviour changes — update `README.md` in the same commit:
+
+- New keyboard shortcut → add a row to the shortcuts table
+- New feature → add a bullet to the Features section
+- Changed build dependency → update the Dependencies section
+- Removed feature → remove or update the relevant entry
+
+Do not leave documentation out of sync with the code.
+
+## Commits
+
+After completing each feature or fix, create a git commit immediately. Do not batch multiple features into one commit. Each commit should be self-contained and buildable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,3 @@ Whenever new functionality is added — new UI controls, keyboard shortcuts, CLI
 
 Do not leave documentation out of sync with the code.
 
-## Commits
-
-After completing each feature or fix, create a git commit immediately. Do not batch multiple features into one commit. Each commit should be self-contained and buildable.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A lightweight HPGL file viewer built with Dear ImGui + OpenGL3 + GLFW.
   - **Threshold** slider: minimum move length to flag/fix (cm)
   - **Waypoint spacing** slider: distance between inserted dots (cm)
   - **Left zone** slider: only fix moves that start within the leftmost X% of the document
+- Merge close strokes: combines consecutive same-pen strokes whose gap (end→start) is ≤ the pen's configured width, eliminating unnecessary pen-up/down movements between nearly-adjacent strokes; chains of strokes are merged together
 - PNG export at physical DPI
 
 ## Keyboard shortcuts

--- a/README.md
+++ b/README.md
@@ -13,19 +13,30 @@ A lightweight HPGL file viewer built with Dear ImGui + OpenGL3 + GLFW.
 
 ## Features
 
-- Open `.hpgl` / `.plt` files via path input
-- Fit-to-window button
-- Pan (left-drag or middle-drag)
-- Zoom to cursor (scroll wheel)
+- Open `.hpgl` / `.plt` files via path input, drag-and-drop, or `O` key
+- Add multiple files as layers (`A` key or drag-and-drop additional files)
+- Pan (left-drag or middle-drag), zoom to cursor (scroll wheel), rotate 90° (`R`)
+- Fit-to-window (`C`), fullscreen (`F`)
 - Per-pen color (color picker) and line thickness (slider)
 - Plotter coordinate tooltip on hover
+- Pen-up move visualisation: green = short, orange = long but outside zone, red = will be fixed
+- Pen-up smear fix: inserts pen-8 waypoint dots along long pen-up moves, exported as a separate `_fixed.hpgl` file
+  - **Threshold** slider: minimum move length to flag/fix (cm)
+  - **Waypoint spacing** slider: distance between inserted dots (cm)
+  - **Left zone** slider: only fix moves that start within the leftmost X% of the document
+- PNG export at physical DPI
 
 ## Keyboard shortcuts
 
-- o: open file
-- f: fullscreen
-- q: quit
-- c: fit to window
+| Key | Action |
+|-----|--------|
+| `O` | Open file (replaces current) |
+| `A` | Add file as additional layer |
+| `F` | Toggle fullscreen |
+| `Q` | Quit |
+| `C` | Fit to window |
+| `R` | Rotate 90° |
+| `E` | Apply pen-up fix (preview in viewport, use Export to save) |
 
 ## Build
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+BUILD_DIR="build"
+
+if [ ! -f "$BUILD_DIR/build.ninja" ]; then
+    meson setup "$BUILD_DIR"
+fi
+
+meson compile -C "$BUILD_DIR"
+sudo meson install -C "$BUILD_DIR"

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,4 @@
+# Memory Index
+
+- [Ask before committing](feedback_commits.md) — Always ask for confirmation before running git commit
+- [Always write tests for new code](feedback_tests.md) — Add tests/test_*.cpp cases for every new function or behaviour change

--- a/memory/feedback_commits.md
+++ b/memory/feedback_commits.md
@@ -1,0 +1,11 @@
+---
+name: Ask before committing
+description: Always ask the user for confirmation before creating a git commit
+type: feedback
+---
+
+Always ask the user for confirmation before running `git commit`. Do not commit automatically after completing a task.
+
+**Why:** User preference — they want to review and approve before any commit is made.
+
+**How to apply:** After finishing a feature or fix, present what would be committed and ask "Ready to commit?" before running git commands.

--- a/memory/feedback_tests.md
+++ b/memory/feedback_tests.md
@@ -1,0 +1,11 @@
+---
+name: Always write tests for new code
+description: User expects new tests to be written alongside any new functionality
+type: feedback
+---
+
+Always write tests for new functionality. When adding or changing behaviour, add corresponding test cases in the relevant `tests/test_*.cpp` file and register them in `main()` in the same commit.
+
+**Why:** User explicitly requested this as a standing rule.
+
+**How to apply:** For every new function, feature, or behaviour change, add tests covering it in the appropriate `tests/test_*.cpp` file and register them in `main()`.

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project('hpgl-viewer', 'cpp',
 glfw_dep  = dependency('glfw3')
 gl_dep    = dependency('gl')
 opengl_dep = dependency('opengl', required: false)
+png_dep   = dependency('libpng')
 
 # ── ImGui (vendored or system) ────────────────────────────────────────────────
 # We expect imgui sources in subprojects/imgui/ (wrap or manual clone).
@@ -42,11 +43,17 @@ renderer_lib = static_library('hpgl_renderer',
   include_directories : include_directories('src'),
   dependencies : [glfw_dep, gl_dep, imgui_dep])
 
+export_png_lib = static_library('hpgl_export_png',
+  sources : ['src/export_png.cpp'],
+  link_with : [parser_lib, fix_lib, renderer_lib],
+  include_directories : include_directories('src'),
+  dependencies : [png_dep, imgui_dep])
+
 executable('hpgl-viewer',
   sources : ['src/main.cpp'],
-  link_with : [parser_lib, fix_lib, config_lib, view_lib, renderer_lib],
+  link_with : [parser_lib, fix_lib, config_lib, view_lib, renderer_lib, export_png_lib],
   include_directories : include_directories('src'),
-  dependencies : [glfw_dep, gl_dep, imgui_dep],
+  dependencies : [glfw_dep, gl_dep, imgui_dep, png_dep],
   install : true)
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
@@ -87,6 +94,14 @@ renderer_test_exe = executable('test_renderer',
   dependencies : [glfw_dep, gl_dep, imgui_dep])
 
 test('renderer', renderer_test_exe)
+
+export_png_test_exe = executable('test_export_png',
+  sources : ['tests/test_export_png.cpp'],
+  link_with : [parser_lib, fix_lib, renderer_lib, export_png_lib],
+  include_directories : include_directories('src'),
+  dependencies : [png_dep, imgui_dep])
+
+test('export png', export_png_test_exe)
 
 # ── Desktop integration ───────────────────────────────────────────────────────
 

--- a/meson.build
+++ b/meson.build
@@ -27,9 +27,24 @@ fix_lib = static_library('hpgl_fix',
   link_with : parser_lib,
   include_directories : include_directories('src'))
 
+config_lib = static_library('hpgl_config',
+  sources : ['src/config.cpp'],
+  include_directories : include_directories('src'))
+
+view_lib = static_library('hpgl_view',
+  sources : ['src/view_state.cpp'],
+  link_with : parser_lib,
+  include_directories : include_directories('src'))
+
+renderer_lib = static_library('hpgl_renderer',
+  sources : ['src/renderer.cpp'],
+  link_with : [parser_lib, fix_lib],
+  include_directories : include_directories('src'),
+  dependencies : [glfw_dep, gl_dep, imgui_dep])
+
 executable('hpgl-viewer',
   sources : ['src/main.cpp'],
-  link_with : [parser_lib, fix_lib],
+  link_with : [parser_lib, fix_lib, config_lib, view_lib, renderer_lib],
   include_directories : include_directories('src'),
   dependencies : [glfw_dep, gl_dep, imgui_dep],
   install : true)
@@ -49,7 +64,29 @@ fix_test_exe = executable('test_hpgl_fix',
   include_directories : include_directories('src'))
 
 test('hpgl fix', fix_test_exe,
-  args : [meson.source_root() / 'tests/data'])
+  args : [meson.project_source_root() / 'tests/data'])
+
+config_test_exe = executable('test_config',
+  sources : ['tests/test_config.cpp'],
+  link_with : config_lib,
+  include_directories : include_directories('src'))
+
+test('config', config_test_exe)
+
+view_test_exe = executable('test_view_state',
+  sources : ['tests/test_view_state.cpp'],
+  link_with : [parser_lib, view_lib],
+  include_directories : include_directories('src'))
+
+test('view state', view_test_exe)
+
+renderer_test_exe = executable('test_renderer',
+  sources : ['tests/test_renderer.cpp'],
+  link_with : [parser_lib, fix_lib, renderer_lib],
+  include_directories : include_directories('src'),
+  dependencies : [glfw_dep, gl_dep, imgui_dep])
+
+test('renderer', renderer_test_exe)
 
 # ── Desktop integration ───────────────────────────────────────────────────────
 

--- a/meson.build
+++ b/meson.build
@@ -22,9 +22,14 @@ parser_lib = static_library('hpgl_parser',
   sources : ['src/hpgl_parser.cpp'],
   include_directories : include_directories('src'))
 
+fix_lib = static_library('hpgl_fix',
+  sources : ['src/hpgl_fix.cpp'],
+  link_with : parser_lib,
+  include_directories : include_directories('src'))
+
 executable('hpgl-viewer',
   sources : ['src/main.cpp'],
-  link_with : parser_lib,
+  link_with : [parser_lib, fix_lib],
   include_directories : include_directories('src'),
   dependencies : [glfw_dep, gl_dep, imgui_dep],
   install : true)
@@ -40,7 +45,7 @@ test('hpgl parser', test_exe)
 
 fix_test_exe = executable('test_hpgl_fix',
   sources : ['tests/test_hpgl_fix.cpp'],
-  link_with : parser_lib,
+  link_with : [parser_lib, fix_lib],
   include_directories : include_directories('src'))
 
 test('hpgl fix', fix_test_exe,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,57 @@
+#include "config.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+std::filesystem::path configPath() {
+  const char *xdg = getenv("XDG_CONFIG_HOME");
+  fs::path base = xdg ? fs::path(xdg) : fs::path(getenv("HOME")) / ".config";
+  return base / "hpgl-viewer" / "config";
+}
+
+std::string configLoad(const std::string &key) {
+  std::ifstream f(configPath());
+  std::string line;
+  while (std::getline(f, line)) {
+    if (line.rfind(key + "=", 0) == 0)
+      return line.substr(key.size() + 1);
+  }
+  return {};
+}
+
+void configSave(const std::string &key, const std::string &value) {
+  fs::path path = configPath();
+  fs::create_directories(path.parent_path());
+
+  std::vector<std::string> lines;
+  std::ifstream in(path);
+  std::string line;
+  bool found = false;
+  while (std::getline(in, line)) {
+    if (line.rfind(key + "=", 0) == 0) {
+      lines.push_back(key + "=" + value);
+      found = true;
+    } else {
+      lines.push_back(line);
+    }
+  }
+  in.close();
+  if (!found)
+    lines.push_back(key + "=" + value);
+
+  std::ofstream out(path);
+  for (auto &l : lines)
+    out << l << "\n";
+}
+
+std::string shellEscapeSingleQuoted(const std::string &s) {
+  std::string out;
+  for (char c : s) {
+    if (c == '\'') out += "'\\''";
+    else           out += c;
+  }
+  return out;
+}

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+// Returns the path to the persistent config file.
+std::filesystem::path configPath();
+
+// Reads the value for key from the config file. Returns "" if not found.
+std::string configLoad(const std::string &key);
+
+// Writes (or overwrites) key=value in the config file.
+void configSave(const std::string &key, const std::string &value);
+
+// Shell-escape a string for single-quoted insertion: replace ' with '\''
+std::string shellEscapeSingleQuoted(const std::string &s);

--- a/src/export_png.cpp
+++ b/src/export_png.cpp
@@ -91,7 +91,7 @@ static bool writePng(const std::string &path, const std::vector<uint8_t> &pixels
 // ── Public API ────────────────────────────────────────────────────────────────
 
 bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
-               const std::string &path, int widthPx) {
+               const std::string &path, float dpi) {
   if (doc.empty()) return false;
 
   float docW = doc.maxX - doc.minX;
@@ -99,10 +99,16 @@ bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
   if (docW < 1) docW = 1;
   if (docH < 1) docH = 1;
 
-  // Compute output dimensions (maintain aspect ratio, 5 % margin).
+  // Physical size in inches → pixel dimensions at requested DPI, with 5% margin.
+  constexpr float kMmPerInch = 25.4f;
   constexpr float margin = 0.05f;
+  float docWMm = docW / kHpglUnitsPerMm;
+  float docHMm = docH / kHpglUnitsPerMm;
+  int   widthPx  = static_cast<int>(docWMm / kMmPerInch * dpi / (1.f - 2.f * margin));
+  int   heightPx = static_cast<int>(docHMm / kMmPerInch * dpi / (1.f - 2.f * margin));
+
+  // Scale: HPGL units → pixels
   float scale = static_cast<float>(widthPx) / docW * (1.f - 2.f * margin);
-  int   heightPx = static_cast<int>(docH * scale + 2.f * margin * widthPx);
 
   float panX = widthPx  * margin - doc.minX * scale;
   float panY = heightPx * margin - doc.minY * scale;

--- a/src/export_png.cpp
+++ b/src/export_png.cpp
@@ -1,0 +1,150 @@
+#include "export_png.h"
+
+#include "hpgl_fix.h" // kHpglUnitsPerMm
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include <png.h>
+
+// ── Software rasteriser ───────────────────────────────────────────────────────
+
+// Paint a filled disk of radius r (pixels) at (cx, cy) with alpha blending
+// over the existing RGBA pixel buffer.
+static void paintDisk(std::vector<uint8_t> &px, int w, int h,
+                      int cx, int cy, int r,
+                      uint8_t red, uint8_t grn, uint8_t blu, float alpha) {
+  int x0 = std::max(0, cx - r), x1 = std::min(w - 1, cx + r);
+  int y0 = std::max(0, cy - r), y1 = std::min(h - 1, cy + r);
+  for (int y = y0; y <= y1; ++y) {
+    for (int x = x0; x <= x1; ++x) {
+      int dx = x - cx, dy = y - cy;
+      if (dx*dx + dy*dy > r*r) continue;
+      int idx = (y * w + x) * 4;
+      float a1 = 1.f - alpha;
+      px[idx+0] = (uint8_t)(px[idx+0] * a1 + red * alpha);
+      px[idx+1] = (uint8_t)(px[idx+1] * a1 + grn * alpha);
+      px[idx+2] = (uint8_t)(px[idx+2] * a1 + blu * alpha);
+      // alpha channel stays 255 (opaque)
+    }
+  }
+}
+
+// Rasterise a thick line segment from (x0,y0) to (x1,y1) by stamping
+// filled disks at intervals of max(1, radius) along the segment.
+static void rasteriseSegment(std::vector<uint8_t> &px, int w, int h,
+                              float x0, float y0, float x1, float y1,
+                              int radius,
+                              uint8_t red, uint8_t grn, uint8_t blu,
+                              float alpha) {
+  float dx = x1 - x0, dy = y1 - y0;
+  float len = sqrtf(dx*dx + dy*dy);
+  int   steps = std::max(1, static_cast<int>(ceilf(len / std::max(1, radius))));
+  for (int i = 0; i <= steps; ++i) {
+    float t  = static_cast<float>(i) / steps;
+    int   cx = static_cast<int>(roundf(x0 + t * dx));
+    int   cy = static_cast<int>(roundf(y0 + t * dy));
+    paintDisk(px, w, h, cx, cy, radius, red, grn, blu, alpha);
+  }
+}
+
+// ── PNG writer ────────────────────────────────────────────────────────────────
+
+static bool writePng(const std::string &path, const std::vector<uint8_t> &pixels,
+                     int w, int h) {
+  FILE *fp = fopen(path.c_str(), "wb");
+  if (!fp) return false;
+
+  png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING,
+                                            nullptr, nullptr, nullptr);
+  if (!png) { fclose(fp); return false; }
+
+  png_infop info = png_create_info_struct(png);
+  if (!info) { png_destroy_write_struct(&png, nullptr); fclose(fp); return false; }
+
+  if (setjmp(png_jmpbuf(png))) {
+    png_destroy_write_struct(&png, &info);
+    fclose(fp);
+    return false;
+  }
+
+  png_init_io(png, fp);
+  png_set_IHDR(png, info, (png_uint_32)w, (png_uint_32)h, 8,
+               PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE,
+               PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+  png_write_info(png, info);
+
+  for (int y = 0; y < h; ++y) {
+    auto *row = const_cast<png_bytep>(&pixels[(size_t)y * w * 4]);
+    png_write_row(png, row);
+  }
+
+  png_write_end(png, info);
+  png_destroy_write_struct(&png, &info);
+  fclose(fp);
+  return true;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
+               const std::string &path, int widthPx) {
+  if (doc.empty()) return false;
+
+  float docW = doc.maxX - doc.minX;
+  float docH = doc.maxY - doc.minY;
+  if (docW < 1) docW = 1;
+  if (docH < 1) docH = 1;
+
+  // Compute output dimensions (maintain aspect ratio, 5 % margin).
+  constexpr float margin = 0.05f;
+  float scale = static_cast<float>(widthPx) / docW * (1.f - 2.f * margin);
+  int   heightPx = static_cast<int>(docH * scale + 2.f * margin * widthPx);
+
+  float panX = widthPx  * margin - doc.minX * scale;
+  float panY = heightPx * margin - doc.minY * scale;
+
+  // RGBA pixel buffer — white background
+  std::vector<uint8_t> pixels((size_t)widthPx * heightPx * 4, 0xFF);
+
+  // Rasterise all strokes
+  for (const auto &stroke : doc.strokes) {
+    if (stroke.points.empty()) continue;
+
+    int pi = std::max(0, std::min(stroke.pen - 1, 7));
+    // Convert ImVec4 colour [0,1] → [0,255]
+    uint8_t red = static_cast<uint8_t>(pens[pi].color.x * 255.f);
+    uint8_t grn = static_cast<uint8_t>(pens[pi].color.y * 255.f);
+    uint8_t blu = static_cast<uint8_t>(pens[pi].color.z * 255.f);
+    float   alp = pens[pi].color.w;
+    // Pen radius in pixels: thickness [mm] × (scale [px/HPGL] × kHpglUnitsPerMm)
+    int radius = std::max(1, static_cast<int>(
+        roundf(pens[pi].thickness * scale * kHpglUnitsPerMm * 0.5f)));
+
+    auto toScreen = [&](const Vec2 &v) -> std::pair<float, float> {
+      return {v.x * scale + panX, v.y * scale + panY};
+    };
+
+    // Single-point / dot stroke
+    if (stroke.points.size() == 1 ||
+        (stroke.points.size() == 2 && stroke.points[0] == stroke.points[1])) {
+      auto [sx, sy] = toScreen(stroke.points[0]);
+      paintDisk(pixels, widthPx, heightPx,
+                static_cast<int>(roundf(sx)), static_cast<int>(roundf(sy)),
+                radius, red, grn, blu, alp);
+      continue;
+    }
+
+    for (size_t i = 0; i + 1 < stroke.points.size(); ++i) {
+      auto [x0, y0] = toScreen(stroke.points[i]);
+      auto [x1, y1] = toScreen(stroke.points[i + 1]);
+      rasteriseSegment(pixels, widthPx, heightPx,
+                       x0, y0, x1, y1, radius, red, grn, blu, alp);
+    }
+  }
+
+  return writePng(path, pixels, widthPx, heightPx);
+}

--- a/src/export_png.cpp
+++ b/src/export_png.cpp
@@ -90,7 +90,7 @@ static bool writePng(const std::string &path, const std::vector<uint8_t> &pixels
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
+bool exportPng(const HpglDoc &doc, const PenStyle pens[10],
                const std::string &path, float dpi) {
   if (doc.empty()) return false;
 
@@ -120,7 +120,7 @@ bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
   for (const auto &stroke : doc.strokes) {
     if (stroke.points.empty()) continue;
 
-    int pi = std::max(0, std::min(stroke.pen - 1, 7));
+    int pi = std::max(0, std::min(stroke.pen - 1, 9));
     // Convert ImVec4 colour [0,1] → [0,255]
     uint8_t red = static_cast<uint8_t>(pens[pi].color.x * 255.f);
     uint8_t grn = static_cast<uint8_t>(pens[pi].color.y * 255.f);

--- a/src/export_png.h
+++ b/src/export_png.h
@@ -7,7 +7,7 @@
 
 // Render doc to a PNG file at the given path.
 // Output dimensions are derived from the document's physical size at dpi.
-// pens[0..7] supplies the pen colours and thicknesses.
+// pens[0..9] supplies the pen colours and thicknesses.
 // Returns true on success.
-bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
+bool exportPng(const HpglDoc &doc, const PenStyle pens[10],
                const std::string &path, float dpi = 300.f);

--- a/src/export_png.h
+++ b/src/export_png.h
@@ -10,4 +10,4 @@
 // pens[0..7] supplies the pen colours and thicknesses.
 // Returns true on success.
 bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
-               const std::string &path, float dpi = 600.f);
+               const std::string &path, float dpi = 300.f);

--- a/src/export_png.h
+++ b/src/export_png.h
@@ -6,8 +6,8 @@
 #include <string>
 
 // Render doc to a PNG file at the given path.
-// widthPx sets the output width; height is derived from the doc aspect ratio.
+// Output dimensions are derived from the document's physical size at dpi.
 // pens[0..7] supplies the pen colours and thicknesses.
 // Returns true on success.
 bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
-               const std::string &path, int widthPx = 2000);
+               const std::string &path, float dpi = 600.f);

--- a/src/export_png.h
+++ b/src/export_png.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "hpgl_parser.h"
+#include "renderer.h"   // PenStyle
+
+#include <string>
+
+// Render doc to a PNG file at the given path.
+// widthPx sets the output width; height is derived from the doc aspect ratio.
+// pens[0..7] supplies the pen colours and thicknesses.
+// Returns true on success.
+bool exportPng(const HpglDoc &doc, const PenStyle pens[8],
+               const std::string &path, int widthPx = 2000);

--- a/src/hpgl_fix.cpp
+++ b/src/hpgl_fix.cpp
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <cstdio>
 
-static constexpr float kHpglUnitsPerMm = 40.0f;
 
 HpglDoc fixLongPenUps(const HpglDoc &src, float thresholdUnits,
                       float stepUnits, float cutoffX) {
@@ -71,7 +70,8 @@ bool exportHpgl(const HpglDoc &doc, const std::string &path) {
 
 DocStats computeDocStats(const HpglDoc &doc) {
   DocStats stats;
-  stats.numPaths = static_cast<int>(doc.strokes.size());
+  for (const auto &s : doc.strokes)
+    if (!s.points.empty()) ++stats.numPaths;
 
   for (const auto &s : doc.strokes) {
     for (size_t i = 0; i + 1 < s.points.size(); ++i) {

--- a/src/hpgl_fix.cpp
+++ b/src/hpgl_fix.cpp
@@ -37,6 +37,42 @@ HpglDoc fixLongPenUps(const HpglDoc &src, float thresholdUnits,
   return result;
 }
 
+HpglDoc mergeCloseStrokes(const HpglDoc &src, const float thresholdsUnits[10]) {
+  HpglDoc result;
+  result.minX = src.minX; result.maxX = src.maxX;
+  result.minY = src.minY; result.maxY = src.maxY;
+
+  for (const auto &stroke : src.strokes) {
+    if (stroke.points.empty()) { result.strokes.push_back(stroke); continue; }
+
+    if (!result.strokes.empty()) {
+      Stroke &last = result.strokes.back();
+      if (!last.points.empty() && last.pen == stroke.pen) {
+        int penIdx = stroke.pen - 1;
+        float threshold = (penIdx >= 0 && penIdx < 10) ? thresholdsUnits[penIdx] : 0.0f;
+        Vec2  endPrev   = last.points.back();
+        Vec2  startCur  = stroke.points.front();
+        float dx        = startCur.x - endPrev.x;
+        float dy        = startCur.y - endPrev.y;
+        float distSq    = dx*dx + dy*dy;
+        if (distSq <= threshold * threshold) {
+          for (const auto &p : stroke.points)
+            last.points.push_back(p);
+          last.bboxMin.x = std::min(last.bboxMin.x, stroke.bboxMin.x);
+          last.bboxMin.y = std::min(last.bboxMin.y, stroke.bboxMin.y);
+          last.bboxMax.x = std::max(last.bboxMax.x, stroke.bboxMax.x);
+          last.bboxMax.y = std::max(last.bboxMax.y, stroke.bboxMax.y);
+          continue;
+        }
+      }
+    }
+
+    result.strokes.push_back(stroke);
+  }
+
+  return result;
+}
+
 bool exportHpgl(const HpglDoc &doc, const std::string &path) {
   FILE *f = fopen(path.c_str(), "w");
   if (!f) return false;

--- a/src/hpgl_fix.cpp
+++ b/src/hpgl_fix.cpp
@@ -70,25 +70,31 @@ bool exportHpgl(const HpglDoc &doc, const std::string &path) {
 
 DocStats computeDocStats(const HpglDoc &doc) {
   DocStats stats;
-  for (const auto &s : doc.strokes)
-    if (!s.points.empty()) ++stats.numPaths;
-
+  const Stroke *prev = nullptr; // last non-empty stroke seen
   for (const auto &s : doc.strokes) {
+    if (s.points.empty()) continue;
+    ++stats.numPaths;
+    // pen-down distance within this stroke
     for (size_t i = 0; i + 1 < s.points.size(); ++i) {
       float dx = s.points[i+1].x - s.points[i].x;
       float dy = s.points[i+1].y - s.points[i].y;
       stats.penDownMm += sqrtf(dx*dx + dy*dy);
     }
-  }
-  for (size_t i = 0; i + 1 < doc.strokes.size(); ++i) {
-    const auto &a = doc.strokes[i];
-    const auto &b = doc.strokes[i+1];
-    if (a.points.empty() || b.points.empty()) continue;
-    float dx = b.points.front().x - a.points.back().x;
-    float dy = b.points.front().y - a.points.back().y;
-    stats.penUpMm += sqrtf(dx*dx + dy*dy);
+    // pen-up gap from the end of the previous stroke to the start of this one
+    if (prev) {
+      float dx = s.points.front().x - prev->points.back().x;
+      float dy = s.points.front().y - prev->points.back().y;
+      stats.penUpMm += sqrtf(dx*dx + dy*dy);
+    }
+    prev = &s;
   }
   stats.penDownMm /= kHpglUnitsPerMm;
   stats.penUpMm   /= kHpglUnitsPerMm;
   return stats;
+}
+
+std::string fixedPath(const std::string &src) {
+  auto dot = src.rfind('.');
+  if (dot == std::string::npos) return src + "_fixed.hpgl";
+  return src.substr(0, dot) + "_fixed" + src.substr(dot);
 }

--- a/src/hpgl_fix.cpp
+++ b/src/hpgl_fix.cpp
@@ -73,7 +73,7 @@ HpglDoc mergeCloseStrokes(const HpglDoc &src, const float thresholdsUnits[10]) {
   return result;
 }
 
-bool exportHpgl(const HpglDoc &doc, const std::string &path) {
+bool exportHpgl(const HpglDoc &doc, const std::string &path, int vsValue) {
   FILE *f = fopen(path.c_str(), "w");
   if (!f) return false;
 
@@ -90,6 +90,7 @@ bool exportHpgl(const HpglDoc &doc, const std::string &path) {
     if (stroke.points.size() == 1) {
       fprintf(f, "PD;\n");
     } else {
+      fprintf(f, "VS%d;\n", vsValue);
       fprintf(f, "PD");
       for (size_t i = 1; i < stroke.points.size(); ++i) {
         if (i > 1) fputc(',', f);

--- a/src/hpgl_fix.cpp
+++ b/src/hpgl_fix.cpp
@@ -1,0 +1,94 @@
+#include "hpgl_fix.h"
+
+#include <cmath>
+#include <cstdio>
+
+static constexpr float kHpglUnitsPerMm = 40.0f;
+
+HpglDoc fixLongPenUps(const HpglDoc &src, float thresholdUnits,
+                      float stepUnits, float cutoffX) {
+  HpglDoc result;
+  result.minX = src.minX; result.maxX = src.maxX;
+  result.minY = src.minY; result.maxY = src.maxY;
+
+  for (size_t i = 0; i < src.strokes.size(); ++i) {
+    const auto &stroke = src.strokes[i];
+    if (stroke.points.empty()) { result.strokes.push_back(stroke); continue; }
+
+    if (i > 0 && !src.strokes[i - 1].points.empty()) {
+      Vec2  prev = src.strokes[i - 1].points.back();
+      Vec2  dst  = stroke.points.front();
+      float dx   = dst.x - prev.x;
+      float dy   = dst.y - prev.y;
+      float dist = sqrtf(dx*dx + dy*dy);
+
+      if (dist > thresholdUnits && prev.x <= cutoffX) {
+        int steps = (int)(dist / stepUnits);
+        for (int k = 1; k <= steps; ++k) {
+          float t  = (float)k * stepUnits / dist;
+          Vec2  wp = {prev.x + t * dx, prev.y + t * dy};
+          result.strokes.push_back(Stroke{{wp, wp}, kWaypointPen}); // dot
+        }
+      }
+    }
+
+    result.strokes.push_back(stroke);
+  }
+
+  return result;
+}
+
+bool exportHpgl(const HpglDoc &doc, const std::string &path) {
+  FILE *f = fopen(path.c_str(), "w");
+  if (!f) return false;
+
+  fprintf(f, "IN;\n");
+  int curPen = -1;
+  for (const auto &stroke : doc.strokes) {
+    if (stroke.points.empty()) continue;
+    if (stroke.pen != curPen) {
+      fprintf(f, "SP%d;\n", stroke.pen);
+      curPen = stroke.pen;
+    }
+    const Vec2 &s = stroke.points.front();
+    fprintf(f, "PU%.0f,%.0f;", s.x, s.y);
+    if (stroke.points.size() == 1) {
+      fprintf(f, "PD;\n");
+    } else {
+      fprintf(f, "PD");
+      for (size_t i = 1; i < stroke.points.size(); ++i) {
+        if (i > 1) fputc(',', f);
+        fprintf(f, "%.0f,%.0f", stroke.points[i].x, stroke.points[i].y);
+      }
+      fprintf(f, ";\n");
+    }
+  }
+  fprintf(f, "PU;\n");
+  fprintf(f, "SP0;\n");
+  fclose(f);
+  return true;
+}
+
+DocStats computeDocStats(const HpglDoc &doc) {
+  DocStats stats;
+  stats.numPaths = static_cast<int>(doc.strokes.size());
+
+  for (const auto &s : doc.strokes) {
+    for (size_t i = 0; i + 1 < s.points.size(); ++i) {
+      float dx = s.points[i+1].x - s.points[i].x;
+      float dy = s.points[i+1].y - s.points[i].y;
+      stats.penDownMm += sqrtf(dx*dx + dy*dy);
+    }
+  }
+  for (size_t i = 0; i + 1 < doc.strokes.size(); ++i) {
+    const auto &a = doc.strokes[i];
+    const auto &b = doc.strokes[i+1];
+    if (a.points.empty() || b.points.empty()) continue;
+    float dx = b.points.front().x - a.points.back().x;
+    float dy = b.points.front().y - a.points.back().y;
+    stats.penUpMm += sqrtf(dx*dx + dy*dy);
+  }
+  stats.penDownMm /= kHpglUnitsPerMm;
+  stats.penUpMm   /= kHpglUnitsPerMm;
+  return stats;
+}

--- a/src/hpgl_fix.h
+++ b/src/hpgl_fix.h
@@ -16,8 +16,9 @@ HpglDoc fixLongPenUps(const HpglDoc &src, float thresholdUnits,
                       float stepUnits, float cutoffX);
 
 // Write doc as HPGL.  Single-point strokes become a pen-down touch.
+// Multi-point strokes are preceded by VS<vsValue>; (velocity select, 1–8).
 // Ends with PU; SP0; to park the pen.
-bool exportHpgl(const HpglDoc &doc, const std::string &path);
+bool exportHpgl(const HpglDoc &doc, const std::string &path, int vsValue = 1);
 
 struct DocStats {
   int   numPaths  = 0;

--- a/src/hpgl_fix.h
+++ b/src/hpgl_fix.h
@@ -29,6 +29,12 @@ struct DocStats {
 // Empty strokes (no points) are excluded from numPaths.
 DocStats computeDocStats(const HpglDoc &doc);
 
+// Merge consecutive same-pen strokes whose gap (end of A → start of B) is
+// ≤ the per-pen threshold given in HPGL units (thresholdsUnits[i] applies to
+// pen i+1).  Chain-merging is applied: A→B→C are all merged when each
+// consecutive gap is within threshold.
+HpglDoc mergeCloseStrokes(const HpglDoc &src, const float thresholdsUnits[10]);
+
 // Derive the output path for an exported fix: inserts "_fixed" before the
 // last extension, or appends "_fixed.hpgl" if there is no extension.
 std::string fixedPath(const std::string &src);

--- a/src/hpgl_fix.h
+++ b/src/hpgl_fix.h
@@ -4,7 +4,9 @@
 
 #include <string>
 
-static constexpr int kWaypointPen = 8;
+inline constexpr float kHpglUnitsPerMm = 40.0f;
+inline constexpr float kHpglUnitsPerCm = kHpglUnitsPerMm * 10.0f;
+inline constexpr int   kWaypointPen    = 8;
 
 // For every inter-stroke pen-up move whose Euclidean length exceeds
 // thresholdUnits, insert single-point pen-down stops (pen kWaypointPen) spaced
@@ -18,10 +20,11 @@ HpglDoc fixLongPenUps(const HpglDoc &src, float thresholdUnits,
 bool exportHpgl(const HpglDoc &doc, const std::string &path);
 
 struct DocStats {
-  int   numPaths    = 0;
-  float penDownMm   = 0.0f;
-  float penUpMm     = 0.0f;
+  int   numPaths  = 0;
+  float penDownMm = 0.0f;
+  float penUpMm   = 0.0f;
 };
 
 // Compute path count and total pen-down / pen-up travel in millimetres.
+// Empty strokes (no points) are excluded from numPaths.
 DocStats computeDocStats(const HpglDoc &doc);

--- a/src/hpgl_fix.h
+++ b/src/hpgl_fix.h
@@ -28,3 +28,7 @@ struct DocStats {
 // Compute path count and total pen-down / pen-up travel in millimetres.
 // Empty strokes (no points) are excluded from numPaths.
 DocStats computeDocStats(const HpglDoc &doc);
+
+// Derive the output path for an exported fix: inserts "_fixed" before the
+// last extension, or appends "_fixed.hpgl" if there is no extension.
+std::string fixedPath(const std::string &src);

--- a/src/hpgl_fix.h
+++ b/src/hpgl_fix.h
@@ -2,76 +2,26 @@
 
 #include "hpgl_parser.h"
 
-#include <cmath>
-#include <cstdio>
 #include <string>
 
+static constexpr int kWaypointPen = 8;
+
 // For every inter-stroke pen-up move whose Euclidean length exceeds
-// thresholdUnits, insert single-point pen-down stops (pen 8) spaced
+// thresholdUnits, insert single-point pen-down stops (pen kWaypointPen) spaced
 // stepUnits apart along the direct path.  Only moves whose start X is
 // within cutoffX are considered.
-static HpglDoc fixLongPenUps(const HpglDoc &src, float thresholdUnits,
-                              float stepUnits, float cutoffX) {
-  HpglDoc result;
-  result.minX = src.minX; result.maxX = src.maxX;
-  result.minY = src.minY; result.maxY = src.maxY;
-
-  for (size_t i = 0; i < src.strokes.size(); ++i) {
-    const auto &stroke = src.strokes[i];
-    if (stroke.points.empty()) { result.strokes.push_back(stroke); continue; }
-
-    if (i > 0 && !src.strokes[i - 1].points.empty()) {
-      Vec2  prev = src.strokes[i - 1].points.back();
-      Vec2  dst  = stroke.points.front();
-      float dx   = dst.x - prev.x;
-      float dy   = dst.y - prev.y;
-      float dist = sqrtf(dx*dx + dy*dy);
-
-      if (dist > thresholdUnits && prev.x <= cutoffX) {
-        int steps = (int)(dist / stepUnits);
-        for (int k = 1; k <= steps; ++k) {
-          float t  = (float)k * stepUnits / dist;
-          Vec2  wp = {prev.x + t * dx, prev.y + t * dy};
-          result.strokes.push_back(Stroke{{wp, wp}, 8}); // dot, pen 8
-        }
-      }
-    }
-
-    result.strokes.push_back(stroke);
-  }
-
-  return result;
-}
+HpglDoc fixLongPenUps(const HpglDoc &src, float thresholdUnits,
+                      float stepUnits, float cutoffX);
 
 // Write doc as HPGL.  Single-point strokes become a pen-down touch.
 // Ends with PU; SP0; to park the pen.
-static bool exportHpgl(const HpglDoc &doc, const std::string &path) {
-  FILE *f = fopen(path.c_str(), "w");
-  if (!f) return false;
+bool exportHpgl(const HpglDoc &doc, const std::string &path);
 
-  fprintf(f, "IN;\n");
-  int curPen = -1;
-  for (const auto &stroke : doc.strokes) {
-    if (stroke.points.empty()) continue;
-    if (stroke.pen != curPen) {
-      fprintf(f, "SP%d;\n", stroke.pen);
-      curPen = stroke.pen;
-    }
-    const Vec2 &s = stroke.points.front();
-    fprintf(f, "PU%.0f,%.0f;", s.x, s.y);
-    if (stroke.points.size() == 1) {
-      fprintf(f, "PD;\n");
-    } else {
-      fprintf(f, "PD");
-      for (size_t i = 1; i < stroke.points.size(); ++i) {
-        if (i > 1) fputc(',', f);
-        fprintf(f, "%.0f,%.0f", stroke.points[i].x, stroke.points[i].y);
-      }
-      fprintf(f, ";\n");
-    }
-  }
-  fprintf(f, "PU;\n");
-  fprintf(f, "SP0;\n");
-  fclose(f);
-  return true;
-}
+struct DocStats {
+  int   numPaths    = 0;
+  float penDownMm   = 0.0f;
+  float penUpMm     = 0.0f;
+};
+
+// Compute path count and total pen-down / pen-up travel in millimetres.
+DocStats computeDocStats(const HpglDoc &doc);

--- a/src/hpgl_parser.cpp
+++ b/src/hpgl_parser.cpp
@@ -39,6 +39,14 @@ void HpglParser::updateBounds(float x, float y) {
   doc.maxY = std::max(doc.maxY, y);
 }
 
+void HpglParser::addPoint(float x, float y) {
+  Stroke &s = doc.strokes[curIdx];
+  s.points.push_back({x, y});
+  s.bboxMin.x = std::min(s.bboxMin.x, x); s.bboxMin.y = std::min(s.bboxMin.y, y);
+  s.bboxMax.x = std::max(s.bboxMax.x, x); s.bboxMax.y = std::max(s.bboxMax.y, y);
+  updateBounds(x, y);
+}
+
 void HpglParser::ensureStroke() {
   bool needNew = (curIdx < 0) ||
                  (doc.strokes[curIdx].pen != currentPen);
@@ -46,10 +54,8 @@ void HpglParser::ensureStroke() {
     doc.strokes.push_back({});
     curIdx = static_cast<int>(doc.strokes.size()) - 1;
     doc.strokes[curIdx].pen = currentPen;
-    if (penDown) {
-      doc.strokes[curIdx].points.push_back({cx, cy});
-      updateBounds(cx, cy);
-    }
+    if (penDown)
+      addPoint(cx, cy);
   }
 }
 
@@ -80,23 +86,18 @@ void HpglParser::handlePD(const std::string &params) {
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
     cx = v[i];
     cy = v[i + 1];
-    doc.strokes[curIdx].points.push_back({cx, cy});
-    updateBounds(cx, cy);
+    addPoint(cx, cy);
   }
 }
 
 void HpglParser::handlePA(const std::string &params) {
   auto v = parseCoords(params);
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
+    cx = v[i];
+    cy = v[i + 1];
     if (penDown) {
       ensureStroke();
-      cx = v[i];
-      cy = v[i + 1];
-      doc.strokes[curIdx].points.push_back({cx, cy});
-      updateBounds(cx, cy);
-    } else {
-      cx = v[i];
-      cy = v[i + 1];
+      addPoint(cx, cy);
     }
   }
 }

--- a/src/hpgl_parser.cpp
+++ b/src/hpgl_parser.cpp
@@ -40,12 +40,14 @@ void HpglParser::updateBounds(float x, float y) {
 }
 
 void HpglParser::ensureStroke() {
-  if (!cur || cur->pen != currentPen) {
+  bool needNew = (curIdx < 0) ||
+                 (doc.strokes[curIdx].pen != currentPen);
+  if (needNew) {
     doc.strokes.push_back({});
-    cur = &doc.strokes.back();
-    cur->pen = currentPen;
+    curIdx = static_cast<int>(doc.strokes.size()) - 1;
+    doc.strokes[curIdx].pen = currentPen;
     if (penDown) {
-      cur->points.push_back({cx, cy});
+      doc.strokes[curIdx].points.push_back({cx, cy});
       updateBounds(cx, cy);
     }
   }
@@ -55,12 +57,12 @@ void HpglParser::handleSP(const std::string &params) {
   auto v = parseCoords(params);
   if (!v.empty())
     currentPen = static_cast<int>(v[0]);
-  cur = nullptr;
+  curIdx = -1;
 }
 
 void HpglParser::handlePU(const std::string &params) {
   penDown = false;
-  cur = nullptr;
+  curIdx = -1;
   auto v = parseCoords(params);
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
     cx = v[i];
@@ -72,14 +74,15 @@ void HpglParser::handlePD(const std::string &params) {
   penDown = true;
   auto v = parseCoords(params);
   ensureStroke();
-  if (cur->points.empty()) {
-    cur->points.push_back({cx, cy});
+  auto &s = doc.strokes[curIdx];
+  if (s.points.empty()) {
+    s.points.push_back({cx, cy});
     updateBounds(cx, cy);
   }
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
     cx = v[i];
     cy = v[i + 1];
-    cur->points.push_back({cx, cy});
+    doc.strokes[curIdx].points.push_back({cx, cy});
     updateBounds(cx, cy);
   }
 }
@@ -89,13 +92,14 @@ void HpglParser::handlePA(const std::string &params) {
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
     if (penDown) {
       ensureStroke();
-      if (cur->points.empty()) {
-        cur->points.push_back({cx, cy});
+      auto &s = doc.strokes[curIdx];
+      if (s.points.empty()) {
+        s.points.push_back({cx, cy});
         updateBounds(cx, cy);
       }
       cx = v[i];
       cy = v[i + 1];
-      cur->points.push_back({cx, cy});
+      doc.strokes[curIdx].points.push_back({cx, cy});
       updateBounds(cx, cy);
     } else {
       cx = v[i];
@@ -112,7 +116,7 @@ HpglDoc HpglParser::parse(const std::string &content) {
   currentPen = 1;
   penDown    = false;
   cx = cy    = 0;
-  cur        = nullptr;
+  curIdx     = -1;
 
   size_t pos = 0;
   while (pos < content.size()) {

--- a/src/hpgl_parser.cpp
+++ b/src/hpgl_parser.cpp
@@ -64,6 +64,9 @@ void HpglParser::handlePU(const std::string &params) {
   penDown = false;
   curIdx = -1;
   auto v = parseCoords(params);
+  // HPGL allows multiple coordinate pairs on PU, but only the final position
+  // matters (no pen-down stroke is produced). All intermediate positions are
+  // intentionally discarded.
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
     cx = v[i];
     cy = v[i + 1];

--- a/src/hpgl_parser.cpp
+++ b/src/hpgl_parser.cpp
@@ -74,11 +74,6 @@ void HpglParser::handlePD(const std::string &params) {
   penDown = true;
   auto v = parseCoords(params);
   ensureStroke();
-  auto &s = doc.strokes[curIdx];
-  if (s.points.empty()) {
-    s.points.push_back({cx, cy});
-    updateBounds(cx, cy);
-  }
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
     cx = v[i];
     cy = v[i + 1];
@@ -92,11 +87,6 @@ void HpglParser::handlePA(const std::string &params) {
   for (size_t i = 0; i + 1 < v.size(); i += 2) {
     if (penDown) {
       ensureStroke();
-      auto &s = doc.strokes[curIdx];
-      if (s.points.empty()) {
-        s.points.push_back({cx, cy});
-        updateBounds(cx, cy);
-      }
       cx = v[i];
       cy = v[i + 1];
       doc.strokes[curIdx].points.push_back({cx, cy});

--- a/src/hpgl_parser.h
+++ b/src/hpgl_parser.h
@@ -46,5 +46,5 @@ private:
   int currentPen = 1;
   bool penDown    = false;
   float cx = 0, cy = 0;
-  Stroke *cur = nullptr;
+  int curIdx = -1; // index into doc.strokes, -1 = none
 };

--- a/src/hpgl_parser.h
+++ b/src/hpgl_parser.h
@@ -15,6 +15,9 @@ struct Vec2 {
 struct Stroke {
   std::vector<Vec2> points;
   int pen = 1;
+  // Per-stroke AABB in HPGL units, populated by HpglParser.
+  Vec2 bboxMin{ 1e30f,  1e30f};
+  Vec2 bboxMax{-1e30f, -1e30f};
 };
 
 struct HpglDoc {
@@ -40,6 +43,7 @@ private:
 
   void ensureStroke();
   void updateBounds(float x, float y);
+  void addPoint(float x, float y); // push point + update stroke and doc bounds
   std::vector<float> parseCoords(const std::string &params);
 
   HpglDoc doc;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ static int g_windowedW = 1400, g_windowedH = 900;
 static PenStyle g_pens[10];
 
 static std::string g_fixStatus;
+static int g_vsValue = 1; // velocity select for HPGL export (1–8)
 
 // ─── Layer helpers
 // ───────────────────────────────────────────────────────────
@@ -392,10 +393,22 @@ int main(int argc, char** argv) {
     bool activeHasFixed = g_activeLayer >= 0 &&
                           g_layers[g_activeLayer].hasFixed;
     ImGui::BeginDisabled(!activeHasFixed);
+    {
+      static const char *kVsLabels[] = {
+        "VS1","VS2","VS3","VS4","VS5","VS6","VS7","VS8"
+      };
+      ImGui::SetNextItemWidth(80);
+      if (ImGui::BeginCombo("Velocity", kVsLabels[g_vsValue - 1])) {
+        for (int i = 0; i < 8; ++i)
+          if (ImGui::Selectable(kVsLabels[i], g_vsValue == i + 1))
+            g_vsValue = i + 1;
+        ImGui::EndCombo();
+      }
+    }
     if (ImGui::Button("Export HPGL")) {
       Layer &al = g_layers[g_activeLayer];
       std::string out = fixedPath(al.path);
-      if (exportHpgl(al.doc, out)) {
+      if (exportHpgl(al.doc, out, g_vsValue)) {
         al.path = out;
         al.hasFixed = false;
         g_fixStatus = "Saved: " + out;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,7 @@ static bool g_fitRequested = false;
 static float g_panX = 0, g_panY = 0, g_scale = 1.0f;
 static float g_rotation = 0.0f;
 static bool  g_showPenUp = false;
+static bool  g_showCoords = false;
 static float g_penUpThreshold =  10.0f; // cm
 static float g_fixStepCm      =   2.0f; // cm between inserted waypoints
 static float g_fixLeftPct      =  15.0f; // % of doc width from left that is eligible
@@ -281,6 +282,7 @@ int main(int argc, char** argv) {
 
     ImGui::SeparatorText("View");
     ImGui::Checkbox("Show pen-up moves", &g_showPenUp);
+    ImGui::Checkbox("Show coordinate grid", &g_showCoords);
     ImGui::Text("Scale: %.3f", g_scale);
     ImGui::SameLine();
     if (ImGui::Button("Fit"))
@@ -381,7 +383,8 @@ int main(int argc, char** argv) {
 
     g_penUpRenderer.fbH = g_fbH;
     DrawParams dp{g_panX, g_panY, g_scale, g_rotation,
-                  g_showPenUp, g_penUpThreshold, g_fixLeftPct, g_pens};
+                  g_showPenUp, g_penUpThreshold, g_fixLeftPct, g_pens,
+                  g_showCoords};
     drawHpgl(dl, canvasPos, cW, cH, g_doc, dp, g_penUpRenderer);
 
     // Stats overlay — top-right corner of canvas

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,87 +1,27 @@
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <fstream>
-#include <string>
-#include <vector>
-#include <array>
 #include <filesystem>
-#include <cmath>
+#include <string>
 
-#include "hpgl_parser.h"
+#include "config.h"
 #include "hpgl_fix.h"
+#include "hpgl_parser.h"
+#include "renderer.h"
+#include "view_state.h"
 
-// GL 3.x prototypes — GLFW_INCLUDE_GLEXT makes GLFW include <GL/glext.h>
-// after <GL/gl.h> so the GL base types are already defined.
-#define GL_GLEXT_PROTOTYPES
-#define GLFW_INCLUDE_GLEXT
-
-#include "imgui.h"
 #include "imgui_internal.h"
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
-#include <GLFW/glfw3.h>
-
-// ─── Config
-// ──────────────────────────────────────────────────────────────────
-
-namespace fs = std::filesystem;
-
-static fs::path configPath() {
-  const char *xdg = getenv("XDG_CONFIG_HOME");
-  fs::path base = xdg ? fs::path(xdg) : fs::path(getenv("HOME")) / ".config";
-  return base / "hpgl-viewer" / "config";
-}
-
-static std::string configLoad(const std::string &key) {
-  std::ifstream f(configPath());
-  std::string line;
-  while (std::getline(f, line)) {
-    if (line.rfind(key + "=", 0) == 0)
-      return line.substr(key.size() + 1);
-  }
-  return {};
-}
-
-static void configSave(const std::string &key, const std::string &value) {
-  fs::path path = configPath();
-  fs::create_directories(path.parent_path());
-
-  std::vector<std::string> lines;
-  std::ifstream in(path);
-  std::string line;
-  bool found = false;
-  while (std::getline(in, line)) {
-    if (line.rfind(key + "=", 0) == 0) {
-      lines.push_back(key + "=" + value);
-      found = true;
-    } else {
-      lines.push_back(line);
-    }
-  }
-  in.close();
-  if (!found)
-    lines.push_back(key + "=" + value);
-
-  std::ofstream out(path);
-  for (auto &l : lines)
-    out << l << "\n";
-}
 
 // ─── File dialog
 // ────────────────────────────────────────────────────────────
 
-static std::string g_lastOpenDir;
+namespace fs = std::filesystem;
 
-// Shell-escape a string for single-quoted insertion: replace ' with '\''
-static std::string shellEscapeSingleQuoted(const std::string &s) {
-  std::string out;
-  for (char c : s) {
-    if (c == '\'') out += "'\\''";
-    else           out += c;
-  }
-  return out;
-}
+static std::string g_lastOpenDir;
 
 static std::string openFileDialog() {
   std::string startDir = g_lastOpenDir;
@@ -112,11 +52,6 @@ static std::string openFileDialog() {
 // ─── App state
 // ────────────────────────────────────────────────────────────────
 
-struct PenStyle {
-  ImVec4 color = {0.1f, 0.1f, 0.1f, 1.0f};
-  float thickness = 0.3f; // mm
-};
-
 static HpglDoc g_doc;
 static std::string g_filePath;
 static char g_filePathBuf[4096] = ""; // PATH_MAX on Linux
@@ -145,41 +80,6 @@ static int g_windowedW = 1400, g_windowedH = 900;
 // pen styles (up to 8 pens)
 static PenStyle g_pens[8];
 
-static void initPenColors() {
-  ImVec4 defaults[] = {
-      {0.05f, 0.05f, 0.05f, 1}, // 1 black
-      {0.8f, 0.1f, 0.1f, 1},    // 2 red
-      {0.1f, 0.5f, 0.1f, 1},    // 3 green
-      {0.1f, 0.1f, 0.8f, 1},    // 4 blue
-      {0.7f, 0.5f, 0.0f, 1},    // 5 orange
-      {0.5f, 0.0f, 0.5f, 1},    // 6 purple
-      {0.0f, 0.5f, 0.5f, 1},    // 7 teal
-      {0.4f, 0.4f, 0.4f, 1},    // 8 grey
-  };
-  for (int i = 0; i < 8; ++i)
-    g_pens[i].color = defaults[i];
-}
-
-static void fitView(float canvasW, float canvasH) {
-  if (g_doc.empty())
-    return;
-  float docW = g_doc.maxX - g_doc.minX;
-  float docH = g_doc.maxY - g_doc.minY;
-  if (docW < 1) docW = 1;
-  if (docH < 1) docH = 1;
-
-  float absC = fabsf(cosf(g_rotation));
-  float absS = fabsf(sinf(g_rotation));
-  float effW = docW * absC + docH * absS;
-  float effH = docW * absS + docH * absC;
-
-  float pad = 0.05f;
-  g_scale = std::min(canvasW / effW, canvasH / effH) * (1.0f - 2.0f * pad);
-
-  g_panX = canvasW * 0.5f - (g_doc.minX + docW * 0.5f) * g_scale;
-  g_panY = canvasH * 0.5f - (g_doc.minY + docH * 0.5f) * g_scale;
-}
-
 static void toggleFullscreen(GLFWwindow *window) {
   if (!g_isFullscreen) {
     glfwGetWindowPos(window, &g_windowedX, &g_windowedY);
@@ -196,290 +96,7 @@ static void toggleFullscreen(GLFWwindow *window) {
   }
 }
 
-// ─── Pen-up GPU renderer
-// ─────────────────────────────────────────────────
-
-// Vertex shader: transforms HPGL coords to NDC using pan/zoom/rotation uniforms.
-// NDC conversion mirrors ImGui's own orthographic projection exactly:
-//   ndcX = (sx - DisplayPos.x) / DisplaySize.x * 2 - 1
-//   ndcY = 1 - (sy - DisplayPos.y) / DisplaySize.y * 2
-static const char *kPenUpVertSrc = R"glsl(
-#version 330 core
-layout(location = 0) in vec2  aPos;    // HPGL coordinates
-layout(location = 1) in float aLenSq;  // squared segment length (HPGL units²)
-layout(location = 2) in float aStartX; // HPGL X of segment start (same for both verts)
-
-uniform float uScale, uCosR, uSinR, uPanX, uPanY;
-uniform float uOriginX, uOriginY, uCanvasW, uCanvasH;
-uniform float uDispX, uDispY, uDispW, uDispH;  // ImGui DisplayPos / DisplaySize
-
-out float vLenSq;
-out float vStartX;
-
-void main() {
-    vLenSq  = aLenSq;
-    vStartX = aStartX;
-    // HPGL → rotated screen space (matches xfPoint() in CPU code)
-    float lx = aPos.x * uScale + uPanX - uCanvasW * 0.5;
-    float ly = aPos.y * uScale + uPanY - uCanvasH * 0.5;
-    float sx = uOriginX + lx * uCosR - ly * uSinR + uCanvasW * 0.5;
-    float sy = uOriginY + lx * uSinR + ly * uCosR + uCanvasH * 0.5;
-    // screen → NDC using ImGui's projection (DisplayPos / DisplaySize)
-    gl_Position = vec4(
-        (sx - uDispX) / uDispW * 2.0 - 1.0,
-        1.0 - (sy - uDispY) / uDispH * 2.0,
-        0.0, 1.0);
-}
-)glsl";
-
-static const char *kPenUpFragSrc = R"glsl(
-#version 330 core
-in float vLenSq;
-in float vStartX;
-uniform float uThresholdSq;
-uniform float uCutoffX;   // HPGL X cutoff (left-zone boundary)
-out vec4 fragColor;
-
-void main() {
-    bool isLong = vLenSq  > uThresholdSq;
-    bool inZone = vStartX <= uCutoffX;
-    if (isLong && inZone)
-        fragColor = vec4(220.0/255.0,  50.0/255.0,  50.0/255.0, 200.0/255.0); // red: will fix
-    else if (isLong)
-        fragColor = vec4(220.0/255.0, 150.0/255.0,  50.0/255.0, 180.0/255.0); // orange: long, skipped
-    else
-        fragColor = vec4( 60.0/255.0, 220.0/255.0, 100.0/255.0, 160.0/255.0); // green: short
-}
-)glsl";
-
-struct PenUpRenderer {
-  GLuint vao = 0, vbo = 0, program = 0;
-  int    vertexCount = 0;
-  bool   valid = false;
-
-  // Per-frame context — filled before issuing the draw callback
-  ImVec2 origin{};
-  float  cW = 0, cH = 0;
-  float  thresholdSq = 0;
-  float  cutoffX = 0;
-  float  dispX = 0, dispY = 0, dispW = 1, dispH = 1; // ImGui DisplayPos/Size
-
-  GLint uScale=-1, uCosR=-1, uSinR=-1, uPanX=-1, uPanY=-1;
-  GLint uOriginX=-1, uOriginY=-1, uCanvasW=-1, uCanvasH=-1;
-  GLint uDispX=-1, uDispY=-1, uDispW=-1, uDispH=-1, uThresholdSq=-1, uCutoffX=-1;
-
-  void init() {
-    auto compile = [](GLenum type, const char *src) -> GLuint {
-      GLuint s = glCreateShader(type);
-      glShaderSource(s, 1, &src, nullptr);
-      glCompileShader(s);
-      GLint ok = 0;
-      glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
-      if (!ok) {
-        char log[512];
-        glGetShaderInfoLog(s, sizeof(log), nullptr, log);
-        fprintf(stderr, "Shader compile error: %s\n", log);
-      }
-      return s;
-    };
-    GLuint vert = compile(GL_VERTEX_SHADER,   kPenUpVertSrc);
-    GLuint frag = compile(GL_FRAGMENT_SHADER, kPenUpFragSrc);
-    program = glCreateProgram();
-    glAttachShader(program, vert);
-    glAttachShader(program, frag);
-    glLinkProgram(program);
-    {
-      GLint ok = 0;
-      glGetProgramiv(program, GL_LINK_STATUS, &ok);
-      if (!ok) {
-        char log[512];
-        glGetProgramInfoLog(program, sizeof(log), nullptr, log);
-        fprintf(stderr, "Shader link error: %s\n", log);
-      }
-    }
-    glDeleteShader(vert);
-    glDeleteShader(frag);
-
-    uScale       = glGetUniformLocation(program, "uScale");
-    uCosR        = glGetUniformLocation(program, "uCosR");
-    uSinR        = glGetUniformLocation(program, "uSinR");
-    uPanX        = glGetUniformLocation(program, "uPanX");
-    uPanY        = glGetUniformLocation(program, "uPanY");
-    uOriginX     = glGetUniformLocation(program, "uOriginX");
-    uOriginY     = glGetUniformLocation(program, "uOriginY");
-    uCanvasW     = glGetUniformLocation(program, "uCanvasW");
-    uCanvasH     = glGetUniformLocation(program, "uCanvasH");
-    uDispX       = glGetUniformLocation(program, "uDispX");
-    uDispY       = glGetUniformLocation(program, "uDispY");
-    uDispW       = glGetUniformLocation(program, "uDispW");
-    uDispH       = glGetUniformLocation(program, "uDispH");
-    uThresholdSq = glGetUniformLocation(program, "uThresholdSq");
-    uCutoffX     = glGetUniformLocation(program, "uCutoffX");
-
-    glGenVertexArrays(1, &vao);
-    glGenBuffers(1, &vbo);
-    valid = true;
-  }
-
-  // Call once after a new file is loaded.
-  void upload(const HpglDoc &doc) {
-    if (!valid) return;
-    // 4 floats per vertex: x, y, lenSq, startX — 2 vertices per pen-up segment
-    std::vector<float> data;
-    data.reserve(doc.strokes.size() * 8);
-    for (size_t i = 0; i + 1 < doc.strokes.size(); ++i) {
-      const auto &a = doc.strokes[i];
-      const auto &b = doc.strokes[i + 1];
-      if (a.points.empty() || b.points.empty()) continue;
-      float x0 = a.points.back().x,  y0 = a.points.back().y;
-      float x1 = b.points.front().x, y1 = b.points.front().y;
-      float dx = x1 - x0, dy = y1 - y0;
-      float lenSq = dx*dx + dy*dy;
-      // startX is identical for both vertices of the segment
-      data.insert(data.end(), {x0, y0, lenSq, x0,
-                                x1, y1, lenSq, x0});
-    }
-    vertexCount = (int)(data.size() / 4);
-
-    glBindVertexArray(vao);
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    glBufferData(GL_ARRAY_BUFFER,
-                 (GLsizeiptr)(data.size() * sizeof(float)),
-                 data.data(), GL_STATIC_DRAW);
-    constexpr int stride = 4 * sizeof(float);
-    // attrib 0: vec2 position
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride, (void*)0);
-    glEnableVertexAttribArray(0);
-    // attrib 1: float lenSq
-    glVertexAttribPointer(1, 1, GL_FLOAT, GL_FALSE, stride, (void*)(2 * sizeof(float)));
-    glEnableVertexAttribArray(1);
-    // attrib 2: float startX
-    glVertexAttribPointer(2, 1, GL_FLOAT, GL_FALSE, stride, (void*)(3 * sizeof(float)));
-    glEnableVertexAttribArray(2);
-    glBindVertexArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-  }
-
-  void draw() const {
-    if (!valid || vertexCount == 0) return;
-    glUseProgram(program);
-    glUniform1f(uScale,       g_scale);
-    glUniform1f(uCosR,        cosf(g_rotation));
-    glUniform1f(uSinR,        sinf(g_rotation));
-    glUniform1f(uPanX,        g_panX);
-    glUniform1f(uPanY,        g_panY);
-    glUniform1f(uOriginX,     origin.x);
-    glUniform1f(uOriginY,     origin.y);
-    glUniform1f(uCanvasW,     cW);
-    glUniform1f(uCanvasH,     cH);
-    glUniform1f(uDispX,       dispX);
-    glUniform1f(uDispY,       dispY);
-    glUniform1f(uDispW,       dispW);
-    glUniform1f(uDispH,       dispH);
-    glUniform1f(uThresholdSq, thresholdSq);
-    glUniform1f(uCutoffX,     cutoffX);
-    glBindVertexArray(vao);
-    glDrawArrays(GL_LINES, 0, vertexCount);
-    glBindVertexArray(0);
-  }
-};
-
 static PenUpRenderer g_penUpRenderer;
-
-static void penUpRenderCallback(const ImDrawList*, const ImDrawCmd *cmd) {
-  auto *r = static_cast<PenUpRenderer*>(cmd->UserCallbackData);
-
-  // Convert ImGui clip rect to GL scissor (framebuffer coords, y-flipped).
-  ImDrawData *dd = ImGui::GetDrawData();
-  float scaleX = dd->FramebufferScale.x, scaleY = dd->FramebufferScale.y;
-  float ox = dd->DisplayPos.x,           oy     = dd->DisplayPos.y;
-  int x1 = (int)((cmd->ClipRect.x - ox) * scaleX);
-  int y1 = (int)((cmd->ClipRect.y - oy) * scaleY);
-  int x2 = (int)((cmd->ClipRect.z - ox) * scaleX);
-  int y2 = (int)((cmd->ClipRect.w - oy) * scaleY);
-  glScissor(x1, g_fbH - y2, x2 - x1, y2 - y1);
-
-  r->draw();
-}
-
-// ─── Drawing
-// ──────────────────────────────────────────────────────────────────
-
-// Undo canvas rotation around its centre: screen-relative coords → pre-rotation coords.
-static ImVec2 unrotateCanvas(float mx, float my, float cW, float cH,
-                              float cosR, float sinR) {
-  float u = mx - cW * 0.5f;
-  float v = my - cH * 0.5f;
-  return {u * cosR + v * sinR + cW * 0.5f,
-         -u * sinR + v * cosR + cH * 0.5f};
-}
-
-static ImVec2 xfPoint(float hx, float hy, ImVec2 origin, float cW, float cH,
-                      float cosR, float sinR) {
-  float sx = hx * g_scale + g_panX - cW * 0.5f;
-  float sy = hy * g_scale + g_panY - cH * 0.5f;
-  return {origin.x + sx * cosR - sy * sinR + cW * 0.5f,
-          origin.y + sx * sinR + sy * cosR + cH * 0.5f};
-}
-
-static void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW,
-                     float canvasH) {
-  dl->PushClipRect(origin, {origin.x + canvasW, origin.y + canvasH}, true);
-
-  float cosR = cosf(g_rotation);
-  float sinR = sinf(g_rotation);
-
-  // Pen-down strokes (CPU path — typically far fewer total segments)
-  for (auto &stroke : g_doc.strokes) {
-    if (stroke.points.empty())
-      continue;
-    int pi = std::max(0, std::min(stroke.pen - 1, 7));
-    ImU32 col = ImGui::ColorConvertFloat4ToU32(g_pens[pi].color);
-    float screen_thick =
-        std::max(1.0f, g_pens[pi].thickness * kHpglUnitsPerMm * g_scale);
-
-    if (stroke.points.size() == 2 && stroke.points[0] == stroke.points[1]) {
-      ImVec2 p = xfPoint(stroke.points[0].x, stroke.points[0].y, origin,
-                         canvasW, canvasH, cosR, sinR);
-      dl->AddCircleFilled(p, screen_thick * 0.5f, col);
-      continue;
-    }
-
-    for (size_t i = 0; i + 1 < stroke.points.size(); ++i) {
-      ImVec2 p0 = xfPoint(stroke.points[i].x, stroke.points[i].y, origin,
-                          canvasW, canvasH, cosR, sinR);
-      ImVec2 p1 = xfPoint(stroke.points[i + 1].x, stroke.points[i + 1].y,
-                          origin, canvasW, canvasH, cosR, sinR);
-      dl->AddLine(p0, p1, col, screen_thick);
-    }
-  }
-
-  // Pen-up moves — drawn via GPU VBO (one draw call for all segments)
-  if (g_showPenUp && g_penUpRenderer.valid && g_penUpRenderer.vertexCount > 0) {
-    float t = g_penUpThreshold * kHpglUnitsPerCm;
-    float cx = g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX);
-    ImVec2 dp = ImGui::GetMainViewport()->Pos;
-    ImVec2 ds = ImGui::GetIO().DisplaySize;
-    g_penUpRenderer.origin      = origin;
-    g_penUpRenderer.cW          = canvasW;
-    g_penUpRenderer.cH          = canvasH;
-    g_penUpRenderer.thresholdSq = t * t;
-    g_penUpRenderer.cutoffX     = cx;
-    g_penUpRenderer.dispX       = dp.x;
-    g_penUpRenderer.dispY       = dp.y;
-    g_penUpRenderer.dispW       = ds.x;
-    g_penUpRenderer.dispH       = ds.y;
-    dl->AddCallback(penUpRenderCallback, &g_penUpRenderer);
-    dl->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
-
-    // Draw vertical cutoff line in HPGL space
-    ImVec2 lineTop = xfPoint(cx, g_doc.minY, origin, canvasW, canvasH, cosR, sinR);
-    ImVec2 lineBot = xfPoint(cx, g_doc.maxY, origin, canvasW, canvasH, cosR, sinR);
-    dl->AddLine(lineTop, lineBot, IM_COL32(100, 200, 255, 200), 1.5f);
-  }
-
-  dl->PopClipRect();
-}
 
 // ─── Pen-up fix + HPGL export
 // ────────────────────────────────────────────────────────────
@@ -560,7 +177,7 @@ int main(int argc, char** argv) {
 
   g_penUpRenderer.init();
 
-  initPenColors();
+  initPenColors(g_pens);
   g_lastOpenDir = configLoad("last_open_dir");
 
   if (argc > 1)
@@ -710,8 +327,10 @@ int main(int argc, char** argv) {
 
     static ImVec2 lastCanvasSize = {0, 0};
     bool sizeChanged = (cW != lastCanvasSize.x || cH != lastCanvasSize.y);
-    if (g_fitRequested || sizeChanged)
-      fitView(cW, cH);
+    if (g_fitRequested || sizeChanged) {
+      auto vs = fitToCanvas(cW, cH, g_doc, g_rotation);
+      g_scale = vs.scale; g_panX = vs.panX; g_panY = vs.panY;
+    }
     g_fitRequested = false;
     lastCanvasSize = {cW, cH};
 
@@ -748,7 +367,10 @@ int main(int argc, char** argv) {
       g_scale *= factor;
     }
 
-    drawHpgl(dl, canvasPos, cW, cH);
+    g_penUpRenderer.fbH = g_fbH;
+    DrawParams dp{g_panX, g_panY, g_scale, g_rotation,
+                  g_showPenUp, g_penUpThreshold, g_fixLeftPct, g_pens};
+    drawHpgl(dl, canvasPos, cW, cH, g_doc, dp, g_penUpRenderer);
 
     // Stats overlay — top-right corner of canvas
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 #include <array>
 #include <cmath>
 #include <cstdio>
-#include <cstring>
 #include <filesystem>
 #include <string>
 
@@ -52,8 +51,15 @@ static std::string openFileDialog() {
 // ─── App state
 // ────────────────────────────────────────────────────────────────
 
-static HpglDoc g_doc;
-static std::string g_filePath;
+struct Layer {
+  HpglDoc     doc;
+  std::string path;
+  bool        visible  = true;
+  bool        hasFixed = false;
+};
+
+static std::vector<Layer> g_layers;
+static int  g_activeLayer = -1; // index of layer targeted by fix/export
 static char g_filePathBuf[4096] = ""; // PATH_MAX on Linux
 static bool g_fitRequested = false;
 
@@ -69,9 +75,8 @@ static float g_fixLeftPct      =  15.0f; // % of doc width from left that is eli
 // Framebuffer size (updated each frame)
 static int g_fbW = 0, g_fbH = 0;
 
-// Cached doc stats (recomputed on load)
+// Cached doc stats (recomputed on load/change)
 static DocStats g_stats;
-static void refreshDocStats() { g_stats = computeDocStats(g_doc); }
 
 // fullscreen state
 static bool g_isFullscreen = false;
@@ -81,29 +86,38 @@ static int g_windowedW = 1400, g_windowedH = 900;
 // pen styles (up to 8 pens)
 static PenStyle g_pens[8];
 
-static void toggleFullscreen(GLFWwindow *window) {
-  if (!g_isFullscreen) {
-    glfwGetWindowPos(window, &g_windowedX, &g_windowedY);
-    glfwGetWindowSize(window, &g_windowedW, &g_windowedH);
-    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-    glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height,
-                         mode->refreshRate);
-    g_isFullscreen = true;
-  } else {
-    glfwSetWindowMonitor(window, nullptr, g_windowedX, g_windowedY,
-                         g_windowedW, g_windowedH, 0);
-    g_isFullscreen = false;
+static std::string g_fixStatus;
+
+// ─── Layer helpers
+// ───────────────────────────────────────────────────────────
+
+// Combine all visible layer strokes into one doc for rendering / pen-up GPU.
+static HpglDoc mergedDoc() {
+  HpglDoc m;
+  for (const auto &l : g_layers) {
+    if (!l.visible) continue;
+    for (const auto &s : l.doc.strokes)
+      m.strokes.push_back(s);
+    if (!l.doc.empty()) {
+      m.minX = std::min(m.minX, l.doc.minX);
+      m.minY = std::min(m.minY, l.doc.minY);
+      m.maxX = std::max(m.maxX, l.doc.maxX);
+      m.maxY = std::max(m.maxY, l.doc.maxY);
+    }
   }
+  if (m.minX > m.maxX) { m.minX = m.minY = 0; m.maxX = m.maxY = 1; }
+  return m;
 }
 
 static PenUpRenderer g_penUpRenderer;
 
-// ─── Pen-up fix + HPGL export
-// ────────────────────────────────────────────────────────────
+static void rebuildPenUpRenderer() {
+  g_penUpRenderer.upload(mergedDoc());
+}
 
-static std::string g_fixStatus;  // shown in sidebar after fix/export
-static bool        g_hasFixed = false; // true when g_doc holds a fixed (unsaved) result
+static void refreshDocStats() {
+  g_stats = computeDocStats(mergedDoc());
+}
 
 // ─── Layout
 // ────────────────────────────────────────────────────────────────────
@@ -123,28 +137,52 @@ static void applyDefaultLayout(ImGuiID dockspace_id) {
 // ─── Actions
 // ─────────────────────────────────────────────────────────────────────
 
-static void loadFile(const std::string &path) {
-  g_filePath = path;
-  strncpy(g_filePathBuf, path.c_str(), sizeof(g_filePathBuf) - 1);
-  g_filePathBuf[sizeof(g_filePathBuf) - 1] = '\0';
-  g_doc = HpglParser{}.parseFile(path);
+static void toggleFullscreen(GLFWwindow *window) {
+  if (!g_isFullscreen) {
+    glfwGetWindowPos(window, &g_windowedX, &g_windowedY);
+    glfwGetWindowSize(window, &g_windowedW, &g_windowedH);
+    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
+    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
+    glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height,
+                         mode->refreshRate);
+    g_isFullscreen = true;
+  } else {
+    glfwSetWindowMonitor(window, nullptr, g_windowedX, g_windowedY,
+                         g_windowedW, g_windowedH, 0);
+    g_isFullscreen = false;
+  }
+}
+
+// Load path as a new layer. If replace=true, clear existing layers first.
+static void loadFile(const std::string &path, bool replace = true) {
+  if (replace) {
+    g_layers.clear();
+    g_activeLayer = -1;
+  }
+  Layer layer;
+  layer.path = path;
+  layer.doc  = HpglParser{}.parseFile(path);
+  g_layers.push_back(std::move(layer));
+  g_activeLayer = static_cast<int>(g_layers.size()) - 1;
+  rebuildPenUpRenderer();
   refreshDocStats();
-  g_penUpRenderer.upload(g_doc);
   g_fitRequested = true;
-  g_hasFixed = false;
   g_fixStatus.clear();
 }
 
 static void applyFix() {
-  float cutoff = g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX);
-  g_doc = fixLongPenUps(g_doc,
+  if (g_activeLayer < 0 || g_activeLayer >= static_cast<int>(g_layers.size()))
+    return;
+  Layer &l = g_layers[g_activeLayer];
+  float cutoff = l.doc.minX + (g_fixLeftPct / 100.0f) * (l.doc.maxX - l.doc.minX);
+  l.doc = fixLongPenUps(l.doc,
                         g_penUpThreshold * kHpglUnitsPerCm,
                         g_fixStepCm      * kHpglUnitsPerCm,
                         cutoff);
+  l.hasFixed = true;
+  rebuildPenUpRenderer();
   refreshDocStats();
-  g_penUpRenderer.upload(g_doc);
   g_fitRequested = true;
-  g_hasFixed = true;
   g_fixStatus = "Fixed (not yet saved)";
 }
 
@@ -205,7 +243,7 @@ int main(int argc, char** argv) {
         g_rotation += static_cast<float>(M_PI_2);
         g_fitRequested = true;
       }
-      if (ImGui::IsKeyPressed(ImGuiKey_E) && !g_filePath.empty())
+      if (ImGui::IsKeyPressed(ImGuiKey_E) && g_activeLayer >= 0)
         applyFix();
       if (ImGui::IsKeyPressed(ImGuiKey_O)) {
         std::string path = openFileDialog();
@@ -215,12 +253,16 @@ int main(int argc, char** argv) {
 
     // ── Top status bar ───────────────────────────────────────────────────
     if (ImGui::BeginMainMenuBar()) {
-      if (g_filePath.empty()) {
+      if (g_layers.empty()) {
         ImGui::TextDisabled("No file loaded");
       } else {
-        std::string name = fs::path(g_filePath).filename().string();
-        if (g_hasFixed) name += "  [unsaved fix]";
-        ImGui::TextUnformatted(name.c_str());
+        for (int i = 0; i < static_cast<int>(g_layers.size()); ++i) {
+          if (i > 0) ImGui::TextDisabled("  |  ");
+          std::string name = fs::path(g_layers[i].path).filename().string();
+          if (g_layers[i].hasFixed) name += "*";
+          if (i == g_activeLayer) ImGui::TextUnformatted(name.c_str());
+          else                    ImGui::TextDisabled("%s", name.c_str());
+        }
       }
       ImGui::EndMainMenuBar();
     }
@@ -240,30 +282,78 @@ int main(int argc, char** argv) {
     ImGui::SetNextWindowSize({320, 600}, ImGuiCond_FirstUseEver);
     ImGui::Begin("Controls");
 
-    ImGui::SeparatorText("File");
+    // ── Layers ───────────────────────────────────────────────────────────
+    ImGui::SeparatorText("Layers");
     ImGui::InputText("##path", g_filePathBuf, sizeof(g_filePathBuf));
     ImGui::SameLine();
     if (ImGui::Button("Open"))
       loadFile(g_filePathBuf);
-    if (!g_filePath.empty()) {
-      ImGui::TextDisabled("%s", g_filePath.c_str());
-      ImGui::Text("Strokes: %zu", g_doc.strokes.size());
-      ImGui::Text("Bounds: (%.0f,%.0f)-(%.0f,%.0f)", g_doc.minX, g_doc.minY,
-                  g_doc.maxX, g_doc.maxY);
+    ImGui::SameLine();
+    if (ImGui::Button("Add"))
+      loadFile(g_filePathBuf, /*replace=*/false);
+
+    for (int i = 0; i < static_cast<int>(g_layers.size()); ++i) {
+      ImGui::PushID(i);
+      Layer &l = g_layers[i];
+      bool isActive = (i == g_activeLayer);
+
+      // Visibility checkbox — rebuild GPU data when toggled
+      bool wasVisible = l.visible;
+      ImGui::Checkbox("##vis", &l.visible);
+      if (l.visible != wasVisible) {
+        rebuildPenUpRenderer();
+        refreshDocStats();
+      }
+      ImGui::SameLine();
+
+      // Layer name — click to activate
+      std::string name = fs::path(l.path).filename().string();
+      if (l.hasFixed) name += " *";
+      if (isActive) {
+        ImGui::TextUnformatted(name.c_str());
+      } else {
+        if (ImGui::Selectable(name.c_str(), false,
+                              ImGuiSelectableFlags_None, {0, 0}))
+          g_activeLayer = i;
+      }
+      ImGui::SameLine();
+
+      // Remove button
+      if (ImGui::SmallButton("x")) {
+        g_layers.erase(g_layers.begin() + i);
+        if (g_activeLayer >= static_cast<int>(g_layers.size()))
+          g_activeLayer = static_cast<int>(g_layers.size()) - 1;
+        rebuildPenUpRenderer();
+        refreshDocStats();
+        g_fitRequested = true;
+        ImGui::PopID();
+        break; // iterator invalidated
+      }
+      ImGui::PopID();
+    }
+
+    // Active-layer details
+    if (g_activeLayer >= 0 && g_activeLayer < static_cast<int>(g_layers.size())) {
+      const HpglDoc &ad = g_layers[g_activeLayer].doc;
+      ImGui::Text("Strokes: %zu", ad.strokes.size());
+      ImGui::Text("Bounds: (%.0f,%.0f)-(%.0f,%.0f)",
+                  ad.minX, ad.minY, ad.maxX, ad.maxY);
     }
 
     ImGui::SeparatorText("Fix");
-    ImGui::BeginDisabled(g_filePath.empty());
+    ImGui::BeginDisabled(g_activeLayer < 0);
     if (ImGui::Button("Fix long pen-up jumps  [E]"))
       applyFix();
-    ImGui::BeginDisabled(!g_hasFixed);
+    bool activeHasFixed = g_activeLayer >= 0 &&
+                          g_layers[g_activeLayer].hasFixed;
+    ImGui::BeginDisabled(!activeHasFixed);
     ImGui::SameLine();
     if (ImGui::Button("Export")) {
-      std::string out = fixedPath(g_filePath);
-      if (exportHpgl(g_doc, out)) {
-        g_filePath = out;
-        strncpy(g_filePathBuf, out.c_str(), sizeof(g_filePathBuf) - 1);
-        g_hasFixed = false;
+      Layer &al = g_layers[g_activeLayer];
+      std::string out = fixedPath(al.path);
+      if (exportHpgl(al.doc, out)) {
+        al.path = out;
+        al.hasFixed = false;
         g_fixStatus = "Saved: " + out;
       } else {
         g_fixStatus = "Export failed: " + out;
@@ -342,7 +432,7 @@ int main(int argc, char** argv) {
     static ImVec2 lastCanvasSize = {0, 0};
     bool sizeChanged = (cW != lastCanvasSize.x || cH != lastCanvasSize.y);
     if (g_fitRequested || sizeChanged) {
-      auto vs = fitToCanvas(cW, cH, g_doc, g_rotation);
+      auto vs = fitToCanvas(cW, cH, mergedDoc(), g_rotation);
       g_scale = vs.scale; g_panX = vs.panX; g_panY = vs.panY;
     }
     g_fitRequested = false;
@@ -385,7 +475,7 @@ int main(int argc, char** argv) {
     DrawParams dp{g_panX, g_panY, g_scale, g_rotation,
                   g_showPenUp, g_penUpThreshold, g_fixLeftPct, g_pens,
                   g_showCoords};
-    drawHpgl(dl, canvasPos, cW, cH, g_doc, dp, g_penUpRenderer);
+    drawHpgl(dl, canvasPos, cW, cH, mergedDoc(), dp, g_penUpRenderer);
 
     // Stats overlay — top-right corner of canvas
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,8 +84,8 @@ static bool g_isFullscreen = false;
 static int g_windowedX = 100, g_windowedY = 100;
 static int g_windowedW = 1400, g_windowedH = 900;
 
-// pen styles (up to 8 pens)
-static PenStyle g_pens[8];
+// pen styles (up to 10 pens)
+static PenStyle g_pens[10];
 
 static std::string g_fixStatus;
 
@@ -95,10 +95,14 @@ static std::string g_fixStatus;
 // Combine all visible layer strokes into one doc for rendering / pen-up GPU.
 static HpglDoc mergedDoc() {
   HpglDoc m;
-  for (const auto &l : g_layers) {
+  for (int li = 0; li < static_cast<int>(g_layers.size()); ++li) {
+    const Layer &l = g_layers[li];
     if (!l.visible) continue;
-    for (const auto &s : l.doc.strokes)
+    int layerPen = (li % 8) + 1; // layer 0→pen1, layer 1→pen2, …
+    for (auto s : l.doc.strokes) {
+      s.pen = layerPen;
       m.strokes.push_back(s);
+    }
     if (!l.doc.empty()) {
       m.minX = std::min(m.minX, l.doc.minX);
       m.minY = std::min(m.minY, l.doc.minY);
@@ -191,6 +195,20 @@ static void applyFix() {
   refreshDocStats();
   g_fitRequested = true;
   g_fixStatus = "Fixed (not yet saved)";
+}
+
+static void applyMerge() {
+  if (g_activeLayer < 0 || g_activeLayer >= static_cast<int>(g_layers.size()))
+    return;
+  Layer &l = g_layers[g_activeLayer];
+  float thresholds[10];
+  for (int i = 0; i < 10; ++i)
+    thresholds[i] = g_pens[i].thickness * kHpglUnitsPerMm;
+  l.doc = mergeCloseStrokes(l.doc, thresholds);
+  l.hasFixed = true;
+  rebuildPenUpRenderer();
+  refreshDocStats();
+  g_fixStatus = "Merged (not yet saved)";
 }
 
 // ─── Main
@@ -326,7 +344,7 @@ int main(int argc, char** argv) {
       ImGui::SameLine();
 
       // Color swatch — shows the pen color assigned to this layer by index
-      ImGui::ColorButton("##col", g_pens[i % 8].color,
+      ImGui::ColorButton("##col", g_pens[i % 10].color,
                          ImGuiColorEditFlags_NoTooltip |
                          ImGuiColorEditFlags_NoBorder, {12, 12});
       ImGui::SameLine();
@@ -369,11 +387,12 @@ int main(int argc, char** argv) {
     ImGui::BeginDisabled(g_activeLayer < 0);
     if (ImGui::Button("Fix long pen-up jumps  [E]"))
       applyFix();
+    if (ImGui::Button("Merge close strokes"))
+      applyMerge();
     bool activeHasFixed = g_activeLayer >= 0 &&
                           g_layers[g_activeLayer].hasFixed;
     ImGui::BeginDisabled(!activeHasFixed);
-    ImGui::SameLine();
-    if (ImGui::Button("Export")) {
+    if (ImGui::Button("Export HPGL")) {
       Layer &al = g_layers[g_activeLayer];
       std::string out = fixedPath(al.path);
       if (exportHpgl(al.doc, out)) {
@@ -430,7 +449,7 @@ int main(int argc, char** argv) {
     static const char *kPenWidthLabels[] = {"0.3 mm", "0.4 mm", "0.5 mm",
                                             "0.6 mm", "0.8 mm", "1.0 mm"};
     constexpr int kNumWidths = 6;
-    for (int i = 0; i < 8; ++i) {
+    for (int i = 0; i < 10; ++i) {
       ImGui::PushID(i);
       char label[16];
       snprintf(label, sizeof(label), "Pen %d", i + 1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,17 +112,18 @@ static HpglDoc mergedDoc() {
 
 static PenUpRenderer  g_penUpRenderer;
 static StrokeRenderer g_strokeRenderer;
+static HpglDoc        g_mergedDoc;   // cached — rebuilt only on load/change
 
 static void rebuildRenderers() {
-  HpglDoc merged = mergedDoc();
-  g_penUpRenderer.upload(merged);
-  g_strokeRenderer.upload(merged);
+  g_mergedDoc = mergedDoc();
+  g_penUpRenderer.upload(g_mergedDoc);
+  g_strokeRenderer.upload(g_mergedDoc);
 }
 
 static void rebuildPenUpRenderer() { rebuildRenderers(); }
 
 static void refreshDocStats() {
-  g_stats = computeDocStats(mergedDoc());
+  g_stats = computeDocStats(g_mergedDoc);
 }
 
 // ─── Layout
@@ -383,14 +384,13 @@ int main(int argc, char** argv) {
     ImGui::SeparatorText("Export");
     ImGui::BeginDisabled(g_activeLayer < 0);
     if (ImGui::Button("Export PNG")) {
-      HpglDoc merged = mergedDoc();
       std::string pngPath;
       if (g_activeLayer >= 0)
         pngPath = fs::path(g_layers[g_activeLayer].path)
                       .replace_extension(".png").string();
       else
         pngPath = "export.png";
-      if (exportPng(merged, g_pens, pngPath))
+      if (exportPng(g_mergedDoc, g_pens, pngPath))
         g_fixStatus = "PNG saved: " + pngPath;
       else
         g_fixStatus = "PNG export failed: " + pngPath;
@@ -468,7 +468,7 @@ int main(int argc, char** argv) {
     static ImVec2 lastCanvasSize = {0, 0};
     bool sizeChanged = (cW != lastCanvasSize.x || cH != lastCanvasSize.y);
     if (g_fitRequested || sizeChanged) {
-      auto vs = fitToCanvas(cW, cH, mergedDoc(), g_rotation);
+      auto vs = fitToCanvas(cW, cH, g_mergedDoc, g_rotation);
       g_scale = vs.scale; g_panX = vs.panX; g_panY = vs.panY;
     }
     g_fitRequested = false;
@@ -512,7 +512,7 @@ int main(int argc, char** argv) {
     DrawParams dp{g_panX, g_panY, g_scale, g_rotation,
                   g_showPenUp, g_penUpThreshold, g_fixLeftPct, g_pens,
                   g_showCoords};
-    drawHpgl(dl, canvasPos, cW, cH, mergedDoc(), dp,
+    drawHpgl(dl, canvasPos, cW, cH, g_mergedDoc, dp,
              g_penUpRenderer, g_strokeRenderer);
 
     // Stats overlay — top-right corner of canvas

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,35 +78,29 @@ static std::string openFileDialog() {
   if (!startDir.empty() && startDir.back() != '/')
     startDir += '/';
 
-  std::string kdialog = "kdialog --getopenfilename '";
-  kdialog += startDir.empty() ? "." : startDir;
-  kdialog += "' '*.hpgl *.plt *.hgl' 2>/dev/null";
+  std::string cmd = "kdialog --getopenfilename '";
+  cmd += startDir.empty() ? "." : startDir;
+  cmd += "' '*.hpgl *.plt *.hgl' 2>/dev/null";
 
-  for (const std::string &cmd : {kdialog}) {
-    FILE *f = popen(cmd.c_str(), "r");
-    if (!f)
-      continue;
-    std::array<char, 4096> buf{};
-    fgets(buf.data(), buf.size(), f);
-    int rc = pclose(f);
-    if (rc != 0)
-      continue;
-    std::string path(buf.data());
-    if (!path.empty() && path.back() == '\n')
-      path.pop_back();
-    if (!path.empty()) {
-      g_lastOpenDir = fs::path(path).parent_path().string();
-      configSave("last_open_dir", g_lastOpenDir);
-      return path;
-    }
+  FILE *f = popen(cmd.c_str(), "r");
+  if (!f) return {};
+  std::array<char, 4096> buf{};
+  fgets(buf.data(), buf.size(), f);
+  int rc = pclose(f);
+  if (rc != 0) return {};
+
+  std::string path(buf.data());
+  if (!path.empty() && path.back() == '\n')
+    path.pop_back();
+  if (!path.empty()) {
+    g_lastOpenDir = fs::path(path).parent_path().string();
+    configSave("last_open_dir", g_lastOpenDir);
   }
-  return {};
+  return path;
 }
 
 // ─── App state
 // ────────────────────────────────────────────────────────────────
-
-static constexpr float kHpglUnitsPerMm = 40.0f;
 
 struct PenStyle {
   ImVec4 color = {0.1f, 0.1f, 0.1f, 1.0f};
@@ -387,19 +381,28 @@ static void penUpRenderCallback(const ImDrawList*, const ImDrawCmd *cmd) {
 
   // Convert ImGui clip rect to GL scissor (framebuffer coords, y-flipped).
   ImDrawData *dd = ImGui::GetDrawData();
-  float sx = dd->FramebufferScale.x, sy = dd->FramebufferScale.y;
-  float ox = dd->DisplayPos.x,       oy = dd->DisplayPos.y;
-  int clipX = (int)((cmd->ClipRect.x - ox) * sx);
-  int clipY = (int)((cmd->ClipRect.y - oy) * sy);
-  int clipZ = (int)((cmd->ClipRect.z - ox) * sx);
-  int clipW = (int)((cmd->ClipRect.w - oy) * sy);
-  glScissor(clipX, g_fbH - clipW, clipZ - clipX, clipW - clipY);
+  float scaleX = dd->FramebufferScale.x, scaleY = dd->FramebufferScale.y;
+  float ox = dd->DisplayPos.x,           oy     = dd->DisplayPos.y;
+  int x1 = (int)((cmd->ClipRect.x - ox) * scaleX);
+  int y1 = (int)((cmd->ClipRect.y - oy) * scaleY);
+  int x2 = (int)((cmd->ClipRect.z - ox) * scaleX);
+  int y2 = (int)((cmd->ClipRect.w - oy) * scaleY);
+  glScissor(x1, g_fbH - y2, x2 - x1, y2 - y1);
 
   r->draw();
 }
 
 // ─── Drawing
 // ──────────────────────────────────────────────────────────────────
+
+// Undo canvas rotation around its centre: screen-relative coords → pre-rotation coords.
+static ImVec2 unrotateCanvas(float mx, float my, float cW, float cH,
+                              float cosR, float sinR) {
+  float u = mx - cW * 0.5f;
+  float v = my - cH * 0.5f;
+  return {u * cosR + v * sinR + cW * 0.5f,
+         -u * sinR + v * cosR + cH * 0.5f};
+}
 
 static ImVec2 xfPoint(float hx, float hy, ImVec2 origin, float cW, float cH,
                       float cosR, float sinR) {
@@ -443,7 +446,7 @@ static void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW,
 
   // Pen-up moves — drawn via GPU VBO (one draw call for all segments)
   if (g_showPenUp && g_penUpRenderer.valid && g_penUpRenderer.vertexCount > 0) {
-    float t = g_penUpThreshold * 400.0f; // cm → HPGL units (40 units/mm * 10 mm/cm)
+    float t = g_penUpThreshold * kHpglUnitsPerCm;
     float cx = g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX);
     ImVec2 dp = ImGui::GetMainViewport()->Pos;
     ImVec2 ds = ImGui::GetIO().DisplaySize;
@@ -496,6 +499,34 @@ static void applyDefaultLayout(ImGuiID dockspace_id) {
   ImGui::DockBuilderFinish(dockspace_id);
 }
 
+// ─── Actions
+// ─────────────────────────────────────────────────────────────────────
+
+static void loadFile(const std::string &path) {
+  g_filePath = path;
+  strncpy(g_filePathBuf, path.c_str(), sizeof(g_filePathBuf) - 1);
+  g_filePathBuf[sizeof(g_filePathBuf) - 1] = '\0';
+  g_doc = HpglParser{}.parseFile(path);
+  refreshDocStats();
+  g_penUpRenderer.upload(g_doc);
+  g_fitRequested = true;
+  g_hasFixed = false;
+  g_fixStatus.clear();
+}
+
+static void applyFix() {
+  float cutoff = g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX);
+  g_doc = fixLongPenUps(g_doc,
+                        g_penUpThreshold * kHpglUnitsPerCm,
+                        g_fixStepCm      * kHpglUnitsPerCm,
+                        cutoff);
+  refreshDocStats();
+  g_penUpRenderer.upload(g_doc);
+  g_fitRequested = true;
+  g_hasFixed = true;
+  g_fixStatus = "Fixed (not yet saved)";
+}
+
 // ─── Main
 // ─────────────────────────────────────────────────────────────────────
 
@@ -529,14 +560,8 @@ int main(int argc, char** argv) {
   initPenColors();
   g_lastOpenDir = configLoad("last_open_dir");
 
-  if (argc > 1) {
-      g_filePath = argv[1];
-      strncpy(g_filePathBuf, g_filePath.c_str(), sizeof(g_filePathBuf) - 1);
-      g_doc = HpglParser{}.parseFile(g_filePath);
-      refreshDocStats();
-      g_penUpRenderer.upload(g_doc);
-      g_fitRequested = true;
-  }
+  if (argc > 1)
+    loadFile(argv[1]);
 
   while (!glfwWindowShouldClose(window)) {
     glfwWaitEvents();
@@ -559,27 +584,11 @@ int main(int argc, char** argv) {
         g_rotation += static_cast<float>(M_PI_2);
         g_fitRequested = true;
       }
-      if (ImGui::IsKeyPressed(ImGuiKey_E) && !g_filePath.empty()) {
-        g_doc = fixLongPenUps(g_doc, g_penUpThreshold * 400.0f, g_fixStepCm * 400.0f,
-              g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX));
-        refreshDocStats();
-        g_penUpRenderer.upload(g_doc);
-        g_fitRequested = true;
-        g_hasFixed = true;
-        g_fixStatus = "Fixed (not yet saved)";
-      }
+      if (ImGui::IsKeyPressed(ImGuiKey_E) && !g_filePath.empty())
+        applyFix();
       if (ImGui::IsKeyPressed(ImGuiKey_O)) {
         std::string path = openFileDialog();
-        if (!path.empty()) {
-          g_filePath = path;
-          strncpy(g_filePathBuf, path.c_str(), sizeof(g_filePathBuf) - 1);
-          g_doc = HpglParser{}.parseFile(g_filePath);
-          refreshDocStats();
-          g_penUpRenderer.upload(g_doc);
-          g_fitRequested = true;
-          g_hasFixed = false;
-          g_fixStatus.clear();
-        }
+        if (!path.empty()) loadFile(path);
       }
     }
 
@@ -613,15 +622,8 @@ int main(int argc, char** argv) {
     ImGui::SeparatorText("File");
     ImGui::InputText("##path", g_filePathBuf, sizeof(g_filePathBuf));
     ImGui::SameLine();
-    if (ImGui::Button("Open")) {
-      g_filePath = g_filePathBuf;
-      g_doc = HpglParser{}.parseFile(g_filePath);
-      refreshDocStats();
-      g_penUpRenderer.upload(g_doc);
-      g_fitRequested = true;
-      g_hasFixed = false;
-      g_fixStatus.clear();
-    }
+    if (ImGui::Button("Open"))
+      loadFile(g_filePathBuf);
     if (!g_filePath.empty()) {
       ImGui::TextDisabled("%s", g_filePath.c_str());
       ImGui::Text("Strokes: %zu", g_doc.strokes.size());
@@ -631,15 +633,8 @@ int main(int argc, char** argv) {
 
     ImGui::SeparatorText("Fix");
     ImGui::BeginDisabled(g_filePath.empty());
-    if (ImGui::Button("Fix long pen-up jumps  [E]")) {
-      g_doc = fixLongPenUps(g_doc, g_penUpThreshold * 400.0f, g_fixStepCm * 400.0f,
-              g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX));
-      refreshDocStats();
-      g_penUpRenderer.upload(g_doc);
-      g_fitRequested = true;
-      g_hasFixed = true;
-      g_fixStatus = "Fixed (not yet saved)";
-    }
+    if (ImGui::Button("Fix long pen-up jumps  [E]"))
+      applyFix();
     ImGui::BeginDisabled(!g_hasFixed);
     ImGui::SameLine();
     if (ImGui::Button("Export")) {
@@ -744,10 +739,7 @@ int main(int argc, char** argv) {
       float factor = (io.MouseWheel > 0) ? 1.1f : 0.9f;
       float mx = io.MousePos.x - canvasPos.x;
       float my = io.MousePos.y - canvasPos.y;
-      float u  = mx - cW * 0.5f;
-      float v  = my - cH * 0.5f;
-      float px = u * cosR + v * sinR + cW * 0.5f;
-      float py = -u * sinR + v * cosR + cH * 0.5f;
+      auto [px, py] = unrotateCanvas(mx, my, cW, cH, cosR, sinR);
       g_panX = px - (px - g_panX) * factor;
       g_panY = py - (py - g_panY) * factor;
       g_scale *= factor;
@@ -786,15 +778,10 @@ int main(int argc, char** argv) {
     if (hovered) {
       float mx = io.MousePos.x - canvasPos.x;
       float my = io.MousePos.y - canvasPos.y;
-      // Undo rotation around canvas centre
-      float u = mx - cW * 0.5f;
-      float v = my - cH * 0.5f;
-      float rx =  u * cosR + v * sinR + cW * 0.5f;
-      float ry = -u * sinR + v * cosR + cH * 0.5f;
-      // Undo scale + pan
-      float px = (rx - g_panX) / g_scale;
-      float py = (ry - g_panY) / g_scale;
-      ImGui::SetTooltip("%.0f, %.0f", px, py);
+      auto [rx, ry] = unrotateCanvas(mx, my, cW, cH, cosR, sinR);
+      ImGui::SetTooltip("%.0f, %.0f",
+                        (rx - g_panX) / g_scale,
+                        (ry - g_panY) / g_scale);
     }
 
     ImGui::End();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,7 +481,7 @@ int main(int argc, char** argv) {
 
     // Zoom toward cursor — convert mouse canvas position to pre-rotation space first
     if (hovered && io.MouseWheel != 0.0f) {
-      float factor = (io.MouseWheel > 0) ? 1.1f : 0.9f;
+      float factor = powf(1.1f, io.MouseWheel);
       float mx = io.MousePos.x - canvasPos.x;
       float my = io.MousePos.y - canvasPos.y;
       auto [px, py] = unrotateCanvas(mx, my, cW, cH, cosR, sinR);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ static bool g_fitRequested = false;
 static float g_panX = 0, g_panY = 0, g_scale = 1.0f;
 static float g_rotation = 0.0f;
 static bool  g_showPenUp = false;
-static bool  g_showCoords = false;
+static bool  g_showCoords = true;
 static float g_penUpThreshold =  10.0f; // cm
 static float g_fixStepCm      =   2.0f; // cm between inserted waypoints
 static float g_fixLeftPct      =  15.0f; // % of doc width from left that is eligible

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -292,6 +292,10 @@ int main(int argc, char** argv) {
     }
 
     ImGui::SeparatorText("Pen Styles");
+    static const float kPenWidths[]      = {0.3f, 0.4f, 0.5f, 0.6f, 0.8f, 1.0f};
+    static const char *kPenWidthLabels[] = {"0.3 mm", "0.4 mm", "0.5 mm",
+                                            "0.6 mm", "0.8 mm", "1.0 mm"};
+    constexpr int kNumWidths = 6;
     for (int i = 0; i < 8; ++i) {
       ImGui::PushID(i);
       char label[16];
@@ -300,9 +304,17 @@ int main(int argc, char** argv) {
                         ImGuiColorEditFlags_NoInputs |
                             ImGuiColorEditFlags_AlphaBar);
       ImGui::SameLine();
-      ImGui::SetNextItemWidth(100);
-      ImGui::SliderFloat("##thick", &g_pens[i].thickness, 0.05f, 2.0f,
-                         "%.2f mm");
+      // Find which standard width matches the current thickness (if any).
+      int sel = -1;
+      for (int j = 0; j < kNumWidths; ++j)
+        if (fabsf(g_pens[i].thickness - kPenWidths[j]) < 0.01f) { sel = j; break; }
+      ImGui::SetNextItemWidth(90);
+      if (ImGui::BeginCombo("##thick", sel >= 0 ? kPenWidthLabels[sel] : "custom")) {
+        for (int j = 0; j < kNumWidths; ++j)
+          if (ImGui::Selectable(kPenWidthLabels[j], sel == j))
+            g_pens[i].thickness = kPenWidths[j];
+        ImGui::EndCombo();
+      }
       ImGui::PopID();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include "hpgl_parser.h"
+#include "hpgl_fix.h"
 
 // GL 3.x prototypes — GLFW_INCLUDE_GLEXT makes GLFW include <GL/glext.h>
 // after <GL/gl.h> so the GL base types are already defined.
@@ -129,31 +130,8 @@ static float g_fixLeftPct      =  15.0f; // % of doc width from left that is eli
 static int g_fbW = 0, g_fbH = 0;
 
 // Cached doc stats (recomputed on load)
-static int   g_numPaths    = 0;
-static float g_penDownDist = 0.0f; // mm
-static float g_penUpDist   = 0.0f; // mm
-static void computeDocStats() {
-  g_numPaths    = (int)g_doc.strokes.size();
-  g_penDownDist = 0.0f;
-  g_penUpDist   = 0.0f;
-  for (auto &s : g_doc.strokes) {
-    for (size_t i = 0; i + 1 < s.points.size(); ++i) {
-      float dx = s.points[i+1].x - s.points[i].x;
-      float dy = s.points[i+1].y - s.points[i].y;
-      g_penDownDist += sqrtf(dx*dx + dy*dy);
-    }
-  }
-  for (size_t i = 0; i + 1 < g_doc.strokes.size(); ++i) {
-    const auto &a = g_doc.strokes[i];
-    const auto &b = g_doc.strokes[i+1];
-    if (a.points.empty() || b.points.empty()) continue;
-    float dx = b.points.front().x - a.points.back().x;
-    float dy = b.points.front().y - a.points.back().y;
-    g_penUpDist += sqrtf(dx*dx + dy*dy);
-  }
-  g_penDownDist /= kHpglUnitsPerMm;
-  g_penUpDist   /= kHpglUnitsPerMm;
-}
+static DocStats g_stats;
+static void refreshDocStats() { g_stats = computeDocStats(g_doc); }
 
 // fullscreen state
 static bool g_isFullscreen = false;
@@ -291,6 +269,13 @@ struct PenUpRenderer {
       GLuint s = glCreateShader(type);
       glShaderSource(s, 1, &src, nullptr);
       glCompileShader(s);
+      GLint ok = 0;
+      glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+      if (!ok) {
+        char log[512];
+        glGetShaderInfoLog(s, sizeof(log), nullptr, log);
+        fprintf(stderr, "Shader compile error: %s\n", log);
+      }
       return s;
     };
     GLuint vert = compile(GL_VERTEX_SHADER,   kPenUpVertSrc);
@@ -299,6 +284,15 @@ struct PenUpRenderer {
     glAttachShader(program, vert);
     glAttachShader(program, frag);
     glLinkProgram(program);
+    {
+      GLint ok = 0;
+      glGetProgramiv(program, GL_LINK_STATUS, &ok);
+      if (!ok) {
+        char log[512];
+        glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+        fprintf(stderr, "Shader link error: %s\n", log);
+      }
+    }
     glDeleteShader(vert);
     glDeleteShader(frag);
 
@@ -476,7 +470,6 @@ static void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW,
 
 // ─── Pen-up fix + HPGL export
 // ────────────────────────────────────────────────────────────
-#include "hpgl_fix.h"
 
 // Derive output path: insert "_fixed" before the last extension.
 static std::string fixedPath(const std::string &src) {
@@ -540,7 +533,7 @@ int main(int argc, char** argv) {
       g_filePath = argv[1];
       strncpy(g_filePathBuf, g_filePath.c_str(), sizeof(g_filePathBuf) - 1);
       g_doc = HpglParser{}.parseFile(g_filePath);
-      computeDocStats();
+      refreshDocStats();
       g_penUpRenderer.upload(g_doc);
       g_fitRequested = true;
   }
@@ -569,7 +562,7 @@ int main(int argc, char** argv) {
       if (ImGui::IsKeyPressed(ImGuiKey_E) && !g_filePath.empty()) {
         g_doc = fixLongPenUps(g_doc, g_penUpThreshold * 400.0f, g_fixStepCm * 400.0f,
               g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX));
-        computeDocStats();
+        refreshDocStats();
         g_penUpRenderer.upload(g_doc);
         g_fitRequested = true;
         g_hasFixed = true;
@@ -581,7 +574,7 @@ int main(int argc, char** argv) {
           g_filePath = path;
           strncpy(g_filePathBuf, path.c_str(), sizeof(g_filePathBuf) - 1);
           g_doc = HpglParser{}.parseFile(g_filePath);
-          computeDocStats();
+          refreshDocStats();
           g_penUpRenderer.upload(g_doc);
           g_fitRequested = true;
           g_hasFixed = false;
@@ -623,7 +616,7 @@ int main(int argc, char** argv) {
     if (ImGui::Button("Open")) {
       g_filePath = g_filePathBuf;
       g_doc = HpglParser{}.parseFile(g_filePath);
-      computeDocStats();
+      refreshDocStats();
       g_penUpRenderer.upload(g_doc);
       g_fitRequested = true;
       g_hasFixed = false;
@@ -641,7 +634,7 @@ int main(int argc, char** argv) {
     if (ImGui::Button("Fix long pen-up jumps  [E]")) {
       g_doc = fixLongPenUps(g_doc, g_penUpThreshold * 400.0f, g_fixStepCm * 400.0f,
               g_doc.minX + (g_fixLeftPct / 100.0f) * (g_doc.maxX - g_doc.minX));
-      computeDocStats();
+      refreshDocStats();
       g_penUpRenderer.upload(g_doc);
       g_fitRequested = true;
       g_hasFixed = true;
@@ -766,9 +759,9 @@ int main(int argc, char** argv) {
     {
       char lines[4][48];
       snprintf(lines[0], sizeof(lines[0]), "%.0f FPS", io.Framerate);
-      snprintf(lines[1], sizeof(lines[1]), "%d paths", g_numPaths);
-      snprintf(lines[2], sizeof(lines[2]), "pd %.2f m", g_penDownDist / 1000.0f);
-      snprintf(lines[3], sizeof(lines[3]), "pu %.2f m", g_penUpDist   / 1000.0f);
+      snprintf(lines[1], sizeof(lines[1]), "%d paths", g_stats.numPaths);
+      snprintf(lines[2], sizeof(lines[2]), "pd %.2f m", g_stats.penDownMm / 1000.0f);
+      snprintf(lines[3], sizeof(lines[3]), "pu %.2f m", g_stats.penUpMm   / 1000.0f);
       float pad   = 6.0f;
       float lineH = ImGui::GetTextLineHeight();
       float step  = lineH + 2.0f;
@@ -788,11 +781,19 @@ int main(int argc, char** argv) {
       }
     }
 
-    // Tooltip with plotter coords
+    // Tooltip with plotter coords — invert the full xfPoint() transform:
+    // screen → unrotated canvas → HPGL
     if (hovered) {
-      ImVec2 mp = io.MousePos;
-      float px = (mp.x - canvasPos.x - g_panX) / g_scale;
-      float py = (mp.y - canvasPos.y - g_panY) / g_scale;
+      float mx = io.MousePos.x - canvasPos.x;
+      float my = io.MousePos.y - canvasPos.y;
+      // Undo rotation around canvas centre
+      float u = mx - cW * 0.5f;
+      float v = my - cH * 0.5f;
+      float rx =  u * cosR + v * sinR + cW * 0.5f;
+      float ry = -u * sinR + v * cosR + cH * 0.5f;
+      // Undo scale + pan
+      float px = (rx - g_panX) / g_scale;
+      float py = (ry - g_panY) / g_scale;
       ImGui::SetTooltip("%.0f, %.0f", px, py);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,13 +73,23 @@ static void configSave(const std::string &key, const std::string &value) {
 
 static std::string g_lastOpenDir;
 
+// Shell-escape a string for single-quoted insertion: replace ' with '\''
+static std::string shellEscapeSingleQuoted(const std::string &s) {
+  std::string out;
+  for (char c : s) {
+    if (c == '\'') out += "'\\''";
+    else           out += c;
+  }
+  return out;
+}
+
 static std::string openFileDialog() {
   std::string startDir = g_lastOpenDir;
   if (!startDir.empty() && startDir.back() != '/')
     startDir += '/';
 
   std::string cmd = "kdialog --getopenfilename '";
-  cmd += startDir.empty() ? "." : startDir;
+  cmd += shellEscapeSingleQuoted(startDir.empty() ? "." : startDir);
   cmd += "' '*.hpgl *.plt *.hgl' 2>/dev/null";
 
   FILE *f = popen(cmd.c_str(), "r");
@@ -109,7 +119,7 @@ struct PenStyle {
 
 static HpglDoc g_doc;
 static std::string g_filePath;
-static char g_filePathBuf[1024] = "";
+static char g_filePathBuf[4096] = ""; // PATH_MAX on Linux
 static bool g_fitRequested = false;
 
 // pan/zoom/rotation state
@@ -473,13 +483,6 @@ static void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW,
 
 // ─── Pen-up fix + HPGL export
 // ────────────────────────────────────────────────────────────
-
-// Derive output path: insert "_fixed" before the last extension.
-static std::string fixedPath(const std::string &src) {
-  auto dot = src.rfind('.');
-  if (dot == std::string::npos) return src + "_fixed.hpgl";
-  return src.substr(0, dot) + "_fixed" + src.substr(dot);
-}
 
 static std::string g_fixStatus;  // shown in sidebar after fix/export
 static bool        g_hasFixed = false; // true when g_doc holds a fixed (unsaved) result

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "config.h"
+#include "export_png.h"
 #include "hpgl_fix.h"
 #include "hpgl_parser.h"
 #include "renderer.h"
@@ -361,6 +362,24 @@ int main(int argc, char** argv) {
     }
     ImGui::EndDisabled();
     ImGui::EndDisabled();
+
+    ImGui::SeparatorText("Export");
+    ImGui::BeginDisabled(g_activeLayer < 0);
+    if (ImGui::Button("Export PNG")) {
+      HpglDoc merged = mergedDoc();
+      std::string pngPath;
+      if (g_activeLayer >= 0)
+        pngPath = fs::path(g_layers[g_activeLayer].path)
+                      .replace_extension(".png").string();
+      else
+        pngPath = "export.png";
+      if (exportPng(merged, g_pens, pngPath))
+        g_fixStatus = "PNG saved: " + pngPath;
+      else
+        g_fixStatus = "PNG export failed: " + pngPath;
+    }
+    ImGui::EndDisabled();
+
     ImGui::SetNextItemWidth(150);
     ImGui::SliderFloat("Threshold", &g_penUpThreshold, 1.0f, 200.0f, "%.0f cm");
     ImGui::SetNextItemWidth(150);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,6 +223,13 @@ int main(int argc, char** argv) {
   if (argc > 1)
     loadFile(argv[1]);
 
+  glfwSetDropCallback(window, [](GLFWwindow*, int count, const char** paths) {
+    bool replace = g_layers.empty();
+    for (int i = 0; i < count; ++i) {
+      loadFile(paths[i], replace && i == 0);
+    }
+  });
+
   while (!glfwWindowShouldClose(window)) {
     glfwWaitEvents();
 
@@ -249,6 +256,10 @@ int main(int argc, char** argv) {
       if (ImGui::IsKeyPressed(ImGuiKey_O)) {
         std::string path = openFileDialog();
         if (!path.empty()) loadFile(path);
+      }
+      if (ImGui::IsKeyPressed(ImGuiKey_A)) {
+        std::string path = openFileDialog();
+        if (!path.empty()) loadFile(path, /*replace=*/false);
       }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,6 +325,12 @@ int main(int argc, char** argv) {
       }
       ImGui::SameLine();
 
+      // Color swatch — shows the pen color assigned to this layer by index
+      ImGui::ColorButton("##col", g_pens[i % 8].color,
+                         ImGuiColorEditFlags_NoTooltip |
+                         ImGuiColorEditFlags_NoBorder, {12, 12});
+      ImGui::SameLine();
+
       // Layer name — click to activate
       std::string name = fs::path(l.path).filename().string();
       if (l.hasFixed) name += " *";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,11 +110,16 @@ static HpglDoc mergedDoc() {
   return m;
 }
 
-static PenUpRenderer g_penUpRenderer;
+static PenUpRenderer  g_penUpRenderer;
+static StrokeRenderer g_strokeRenderer;
 
-static void rebuildPenUpRenderer() {
-  g_penUpRenderer.upload(mergedDoc());
+static void rebuildRenderers() {
+  HpglDoc merged = mergedDoc();
+  g_penUpRenderer.upload(merged);
+  g_strokeRenderer.upload(merged);
 }
+
+static void rebuildPenUpRenderer() { rebuildRenderers(); }
 
 static void refreshDocStats() {
   g_stats = computeDocStats(mergedDoc());
@@ -216,6 +221,7 @@ int main(int argc, char** argv) {
   ImGui_ImplOpenGL3_Init("#version 330");
 
   g_penUpRenderer.init();
+  g_strokeRenderer.init();
 
   initPenColors(g_pens);
   g_lastOpenDir = configLoad("last_open_dir");
@@ -501,11 +507,13 @@ int main(int argc, char** argv) {
       g_scale *= factor;
     }
 
-    g_penUpRenderer.fbH = g_fbH;
+    g_penUpRenderer.fbH  = g_fbH;
+    g_strokeRenderer.fbH = g_fbH;
     DrawParams dp{g_panX, g_panY, g_scale, g_rotation,
                   g_showPenUp, g_penUpThreshold, g_fixLeftPct, g_pens,
                   g_showCoords};
-    drawHpgl(dl, canvasPos, cW, cH, mergedDoc(), dp, g_penUpRenderer);
+    drawHpgl(dl, canvasPos, cW, cH, mergedDoc(), dp,
+             g_penUpRenderer, g_strokeRenderer);
 
     // Stats overlay — top-right corner of canvas
     {

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -42,32 +42,75 @@ void main() {
 }
 )glsl";
 
-// Vertex shader for pen-down strokes (2-float vertices, same transform as pen-up).
+// Vertex shader for pen-down strokes.
+// Each segment is a quad extended by uHalfWidth beyond both endpoints (for caps).
+// aPos  = HPGL position of this corner (p0 or p1).
+// aP0/aP1 = canonical segment start/end (same for all 6 vertices of a segment).
+// aSide = +1 or -1: perpendicular side.
+// Outputs local capsule coordinates (vU along axis, vV perpendicular) for the SDF.
 static const char *kStrokeVertSrc = R"glsl(
 #version 330 core
-layout(location = 0) in vec2 aPos;
+layout(location = 0) in vec2  aPos;
+layout(location = 1) in vec2  aP0;
+layout(location = 2) in vec2  aP1;
+layout(location = 3) in float aSide;
 
 uniform float uScale, uCosR, uSinR, uPanX, uPanY;
 uniform float uOriginX, uOriginY, uCanvasW, uCanvasH;
 uniform float uDispX, uDispY, uDispW, uDispH;
+uniform float uHalfWidth;
+
+flat out float vL;
+out float vU;
+out float vV;
+
+vec2 toScreen(vec2 p) {
+    float lx = p.x * uScale + uPanX - uCanvasW * 0.5;
+    float ly = p.y * uScale + uPanY - uCanvasH * 0.5;
+    return vec2(uOriginX + lx * uCosR - ly * uSinR + uCanvasW * 0.5,
+                uOriginY + lx * uSinR + ly * uCosR + uCanvasH * 0.5);
+}
 
 void main() {
-    float lx = aPos.x * uScale + uPanX - uCanvasW * 0.5;
-    float ly = aPos.y * uScale + uPanY - uCanvasH * 0.5;
-    float sx = uOriginX + lx * uCosR - ly * uSinR + uCanvasW * 0.5;
-    float sy = uOriginY + lx * uSinR + ly * uCosR + uCanvasH * 0.5;
+    vec2 sp  = toScreen(aPos);
+    vec2 sp0 = toScreen(aP0);
+    vec2 sp1 = toScreen(aP1);
+    vec2 d   = sp1 - sp0;
+    float L  = length(d);
+    vL = L;
+    vec2 dir  = (L > 0.0001) ? d / L : vec2(1.0, 0.0);
+    vec2 perp = vec2(-dir.y, dir.x);
+
+    // Extend the quad outward along the axis at both ends for the rounded cap region.
+    float u_base   = dot(sp - sp0, dir);
+    float end_sign = (u_base > L * 0.5) ? 1.0 : -1.0;
+    vec2  s        = sp + perp * aSide * uHalfWidth + dir * end_sign * uHalfWidth;
+
+    vU = u_base + end_sign * uHalfWidth;
+    vV = aSide * uHalfWidth;
+
     gl_Position = vec4(
-        (sx - uDispX) / uDispW * 2.0 - 1.0,
-        1.0 - (sy - uDispY) / uDispH * 2.0,
+        (s.x - uDispX) / uDispW * 2.0 - 1.0,
+        1.0 - (s.y - uDispY) / uDispH * 2.0,
         0.0, 1.0);
 }
 )glsl";
 
 static const char *kStrokeFragSrc = R"glsl(
 #version 330 core
+flat in float vL;
+in float vU;
+in float vV;
+uniform float uHalfWidth;
 uniform vec4 uColor;
 out vec4 fragColor;
-void main() { fragColor = uColor; }
+void main() {
+    // Capsule SDF: distance from this fragment to the nearest point on the segment.
+    float nearest_u = clamp(vU, 0.0, vL);
+    float dist = length(vec2(nearest_u - vU, vV));
+    if (dist > uHalfWidth) discard;
+    fragColor = uColor;
+}
 )glsl";
 
 static const char *kPenUpFragSrc = R"glsl(
@@ -92,18 +135,20 @@ void main() {
 
 // ── Pen styling ───────────────────────────────────────────────────────────────
 
-void initPenColors(PenStyle pens[8]) {
+void initPenColors(PenStyle pens[10]) {
   ImVec4 defaults[] = {
-      {0.05f, 0.05f, 0.05f, 1}, // 1 black
-      {0.8f,  0.1f,  0.1f,  1}, // 2 red
-      {0.1f,  0.5f,  0.1f,  1}, // 3 green
-      {0.1f,  0.1f,  0.8f,  1}, // 4 blue
-      {0.7f,  0.5f,  0.0f,  1}, // 5 orange
-      {0.5f,  0.0f,  0.5f,  1}, // 6 purple
-      {0.0f,  0.5f,  0.5f,  1}, // 7 teal
-      {0.4f,  0.4f,  0.4f,  1}, // 8 grey
+      {1.00f, 0.00f, 0.00f, 1}, // 1  red
+      {0.00f, 0.60f, 0.00f, 1}, // 2  green
+      {0.00f, 0.00f, 0.70f, 1}, // 3  blue
+      {1.00f, 0.65f, 0.00f, 1}, // 4  orange
+      {0.35f, 0.15f, 0.03f, 1}, // 5  brown
+      {0.00f, 0.00f, 0.00f, 1}, // 6  black
+      {1.00f, 1.00f, 0.00f, 1}, // 7  yellow
+      {0.40f, 0.00f, 0.60f, 1}, // 8  purple
+      {0.45f, 0.65f, 1.00f, 1}, // 9  light blue
+      {1.00f, 0.00f, 1.00f, 1}, // 10 magenta
   };
-  for (int i = 0; i < 8; ++i)
+  for (int i = 0; i < 10; ++i)
     pens[i].color = defaults[i];
 }
 
@@ -302,7 +347,8 @@ void StrokeRenderer::init() {
   uDispY   = glGetUniformLocation(program, "uDispY");
   uDispW   = glGetUniformLocation(program, "uDispW");
   uDispH   = glGetUniformLocation(program, "uDispH");
-  uColor   = glGetUniformLocation(program, "uColor");
+  uColor     = glGetUniformLocation(program, "uColor");
+  uHalfWidth = glGetUniformLocation(program, "uHalfWidth");
 
   glGenVertexArrays(1, &vao);
   glGenBuffers(1, &vbo);
@@ -312,26 +358,41 @@ void StrokeRenderer::init() {
 void StrokeRenderer::upload(const HpglDoc &doc) {
   if (!valid) return;
 
-  // Collect line-segment vertex pairs per pen (skip single-point dot strokes).
-  std::vector<float> penData[8];
+  // Each segment is rendered as a quad extended beyond both endpoints for rounded caps.
+  // Vertex layout: (pos.x, pos.y, p0.x, p0.y, p1.x, p1.y, side) — 7 floats per vertex.
+  // p0/p1 are the canonical segment endpoints (same for all 6 vertices of a segment).
+  // Skip single-point dot strokes (handled by CPU dot renderer).
+  std::vector<float> penData[10];
   for (const auto &stroke : doc.strokes) {
     if (stroke.points.size() < 2) continue;
     if (stroke.points.size() == 2 && stroke.points[0] == stroke.points[1]) continue;
-    int pi = std::max(0, std::min(stroke.pen - 1, 7));
+    int pi = std::max(0, std::min(stroke.pen - 1, 9));
     for (size_t i = 0; i + 1 < stroke.points.size(); ++i) {
-      penData[pi].push_back(stroke.points[i].x);
-      penData[pi].push_back(stroke.points[i].y);
-      penData[pi].push_back(stroke.points[i + 1].x);
-      penData[pi].push_back(stroke.points[i + 1].y);
+      float x0 = stroke.points[i].x,   y0 = stroke.points[i].y;
+      float x1 = stroke.points[i+1].x, y1 = stroke.points[i+1].y;
+      // Two triangles (A,B,D) and (A,D,C) where:
+      //   A = p0 top, B = p0 bottom, C = p1 top, D = p1 bottom
+      // Layout: (pos, p0, p1, side)
+      float verts[6][7] = {
+        {x0, y0,  x0, y0, x1, y1,  +1.f}, // A
+        {x0, y0,  x0, y0, x1, y1,  -1.f}, // B
+        {x1, y1,  x0, y0, x1, y1,  -1.f}, // D
+        {x0, y0,  x0, y0, x1, y1,  +1.f}, // A
+        {x1, y1,  x0, y0, x1, y1,  -1.f}, // D
+        {x1, y1,  x0, y0, x1, y1,  +1.f}, // C
+      };
+      for (auto &v : verts)
+        for (float f : v)
+          penData[pi].push_back(f);
     }
   }
 
   // Concatenate into one VBO, record per-pen vertex offset/count.
   std::vector<float> vboData;
   int vertOffset = 0;
-  for (int i = 0; i < 8; ++i) {
+  for (int i = 0; i < 10; ++i) {
     ranges[i].offset = vertOffset;
-    ranges[i].count  = (int)(penData[i].size() / 2); // 2 floats per vertex
+    ranges[i].count  = (int)(penData[i].size() / 7); // 7 floats per vertex
     vboData.insert(vboData.end(), penData[i].begin(), penData[i].end());
     vertOffset += ranges[i].count;
   }
@@ -341,9 +402,15 @@ void StrokeRenderer::upload(const HpglDoc &doc) {
   glBufferData(GL_ARRAY_BUFFER,
                (GLsizeiptr)(vboData.size() * sizeof(float)),
                vboData.data(), GL_STATIC_DRAW);
-  constexpr int stride = 2 * sizeof(float);
-  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride, (void*)0);
+  constexpr int stride = 7 * sizeof(float);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride, (void*)0);                    // aPos
   glEnableVertexAttribArray(0);
+  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, stride, (void*)(2 * sizeof(float)));  // aP0
+  glEnableVertexAttribArray(1);
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, (void*)(4 * sizeof(float)));  // aP1
+  glEnableVertexAttribArray(2);
+  glVertexAttribPointer(3, 1, GL_FLOAT, GL_FALSE, stride, (void*)(6 * sizeof(float)));  // aSide
+  glEnableVertexAttribArray(3);
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
@@ -366,16 +433,14 @@ void StrokeRenderer::draw() const {
   glUniform1f(uDispH,   dispH);
 
   glBindVertexArray(vao);
-  for (int i = 0; i < 8; ++i) {
+  for (int i = 0; i < 10; ++i) {
     if (ranges[i].count == 0) continue;
     const auto &c = pens[i].color;
     glUniform4f(uColor, c.x, c.y, c.z, c.w);
-    float lw = std::max(1.0f, pens[i].thickness * kHpglUnitsPerMm * scale);
-    glLineWidth(lw);
-    glDrawArrays(GL_LINES, ranges[i].offset, ranges[i].count);
+    glUniform1f(uHalfWidth, pens[i].thickness * kHpglUnitsPerMm * scale * 0.5f);
+    glDrawArrays(GL_TRIANGLES, ranges[i].offset, ranges[i].count);
   }
   glBindVertexArray(0);
-  glLineWidth(1.0f);
 }
 
 void strokeRenderCallback(const ImDrawList*, const ImDrawCmd *cmd) {
@@ -534,7 +599,7 @@ void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
       if (!(stroke.points[0] == stroke.points[1])) continue;
       if (stroke.bboxMax.x < visMinX || stroke.bboxMin.x > visMaxX ||
           stroke.bboxMax.y < visMinY || stroke.bboxMin.y > visMaxY) continue;
-      int pi = std::max(0, std::min(stroke.pen - 1, 7));
+      int pi = std::max(0, std::min(stroke.pen - 1, 9));
       ImU32 col = ImGui::ColorConvertFloat4ToU32(p.pens[pi].color);
       float screen_thick = std::max(1.0f, p.pens[pi].thickness * kHpglUnitsPerMm * p.scale);
       ImVec2 pt = xfPoint(stroke.points[0].x, stroke.points[0].y, origin,

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1,0 +1,295 @@
+#include "renderer.h"
+
+#include "imgui_internal.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+// ── Shaders ───────────────────────────────────────────────────────────────────
+
+// Vertex shader: transforms HPGL coords to NDC using pan/zoom/rotation uniforms.
+// NDC conversion mirrors ImGui's own orthographic projection exactly:
+//   ndcX = (sx - DisplayPos.x) / DisplaySize.x * 2 - 1
+//   ndcY = 1 - (sy - DisplayPos.y) / DisplaySize.y * 2
+static const char *kPenUpVertSrc = R"glsl(
+#version 330 core
+layout(location = 0) in vec2  aPos;    // HPGL coordinates
+layout(location = 1) in float aLenSq;  // squared segment length (HPGL units²)
+layout(location = 2) in float aStartX; // HPGL X of segment start (same for both verts)
+
+uniform float uScale, uCosR, uSinR, uPanX, uPanY;
+uniform float uOriginX, uOriginY, uCanvasW, uCanvasH;
+uniform float uDispX, uDispY, uDispW, uDispH;  // ImGui DisplayPos / DisplaySize
+
+out float vLenSq;
+out float vStartX;
+
+void main() {
+    vLenSq  = aLenSq;
+    vStartX = aStartX;
+    // HPGL → rotated screen space (matches xfPoint() in CPU code)
+    float lx = aPos.x * uScale + uPanX - uCanvasW * 0.5;
+    float ly = aPos.y * uScale + uPanY - uCanvasH * 0.5;
+    float sx = uOriginX + lx * uCosR - ly * uSinR + uCanvasW * 0.5;
+    float sy = uOriginY + lx * uSinR + ly * uCosR + uCanvasH * 0.5;
+    // screen → NDC using ImGui's projection (DisplayPos / DisplaySize)
+    gl_Position = vec4(
+        (sx - uDispX) / uDispW * 2.0 - 1.0,
+        1.0 - (sy - uDispY) / uDispH * 2.0,
+        0.0, 1.0);
+}
+)glsl";
+
+static const char *kPenUpFragSrc = R"glsl(
+#version 330 core
+in float vLenSq;
+in float vStartX;
+uniform float uThresholdSq;
+uniform float uCutoffX;   // HPGL X cutoff (left-zone boundary)
+out vec4 fragColor;
+
+void main() {
+    bool isLong = vLenSq  > uThresholdSq;
+    bool inZone = vStartX <= uCutoffX;
+    if (isLong && inZone)
+        fragColor = vec4(220.0/255.0,  50.0/255.0,  50.0/255.0, 200.0/255.0); // red: will fix
+    else if (isLong)
+        fragColor = vec4(220.0/255.0, 150.0/255.0,  50.0/255.0, 180.0/255.0); // orange: long, skipped
+    else
+        fragColor = vec4( 60.0/255.0, 220.0/255.0, 100.0/255.0, 160.0/255.0); // green: short
+}
+)glsl";
+
+// ── Pen styling ───────────────────────────────────────────────────────────────
+
+void initPenColors(PenStyle pens[8]) {
+  ImVec4 defaults[] = {
+      {0.05f, 0.05f, 0.05f, 1}, // 1 black
+      {0.8f,  0.1f,  0.1f,  1}, // 2 red
+      {0.1f,  0.5f,  0.1f,  1}, // 3 green
+      {0.1f,  0.1f,  0.8f,  1}, // 4 blue
+      {0.7f,  0.5f,  0.0f,  1}, // 5 orange
+      {0.5f,  0.0f,  0.5f,  1}, // 6 purple
+      {0.0f,  0.5f,  0.5f,  1}, // 7 teal
+      {0.4f,  0.4f,  0.4f,  1}, // 8 grey
+  };
+  for (int i = 0; i < 8; ++i)
+    pens[i].color = defaults[i];
+}
+
+// ── Coordinate helpers ────────────────────────────────────────────────────────
+
+ImVec2 unrotateCanvas(float mx, float my, float cW, float cH,
+                      float cosR, float sinR) {
+  float u = mx - cW * 0.5f;
+  float v = my - cH * 0.5f;
+  return {u * cosR + v * sinR + cW * 0.5f,
+         -u * sinR + v * cosR + cH * 0.5f};
+}
+
+ImVec2 xfPoint(float hx, float hy, ImVec2 origin,
+               float panX, float panY, float scale,
+               float cW, float cH, float cosR, float sinR) {
+  float sx = hx * scale + panX - cW * 0.5f;
+  float sy = hy * scale + panY - cH * 0.5f;
+  return {origin.x + sx * cosR - sy * sinR + cW * 0.5f,
+          origin.y + sx * sinR + sy * cosR + cH * 0.5f};
+}
+
+// ── GPU pen-up renderer ───────────────────────────────────────────────────────
+
+void PenUpRenderer::init() {
+  auto compile = [](GLenum type, const char *src) -> GLuint {
+    GLuint s = glCreateShader(type);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
+    GLint ok = 0;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+      char log[512];
+      glGetShaderInfoLog(s, sizeof(log), nullptr, log);
+      fprintf(stderr, "Shader compile error: %s\n", log);
+    }
+    return s;
+  };
+  GLuint vert = compile(GL_VERTEX_SHADER,   kPenUpVertSrc);
+  GLuint frag = compile(GL_FRAGMENT_SHADER, kPenUpFragSrc);
+  program = glCreateProgram();
+  glAttachShader(program, vert);
+  glAttachShader(program, frag);
+  glLinkProgram(program);
+  {
+    GLint ok = 0;
+    glGetProgramiv(program, GL_LINK_STATUS, &ok);
+    if (!ok) {
+      char log[512];
+      glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+      fprintf(stderr, "Shader link error: %s\n", log);
+    }
+  }
+  glDeleteShader(vert);
+  glDeleteShader(frag);
+
+  uScale       = glGetUniformLocation(program, "uScale");
+  uCosR        = glGetUniformLocation(program, "uCosR");
+  uSinR        = glGetUniformLocation(program, "uSinR");
+  uPanX        = glGetUniformLocation(program, "uPanX");
+  uPanY        = glGetUniformLocation(program, "uPanY");
+  uOriginX     = glGetUniformLocation(program, "uOriginX");
+  uOriginY     = glGetUniformLocation(program, "uOriginY");
+  uCanvasW     = glGetUniformLocation(program, "uCanvasW");
+  uCanvasH     = glGetUniformLocation(program, "uCanvasH");
+  uDispX       = glGetUniformLocation(program, "uDispX");
+  uDispY       = glGetUniformLocation(program, "uDispY");
+  uDispW       = glGetUniformLocation(program, "uDispW");
+  uDispH       = glGetUniformLocation(program, "uDispH");
+  uThresholdSq = glGetUniformLocation(program, "uThresholdSq");
+  uCutoffX     = glGetUniformLocation(program, "uCutoffX");
+
+  glGenVertexArrays(1, &vao);
+  glGenBuffers(1, &vbo);
+  valid = true;
+}
+
+void PenUpRenderer::upload(const HpglDoc &doc) {
+  if (!valid) return;
+  // 4 floats per vertex: x, y, lenSq, startX — 2 vertices per pen-up segment
+  std::vector<float> data;
+  data.reserve(doc.strokes.size() * 8);
+  for (size_t i = 0; i + 1 < doc.strokes.size(); ++i) {
+    const auto &a = doc.strokes[i];
+    const auto &b = doc.strokes[i + 1];
+    if (a.points.empty() || b.points.empty()) continue;
+    float x0 = a.points.back().x,  y0 = a.points.back().y;
+    float x1 = b.points.front().x, y1 = b.points.front().y;
+    float dx = x1 - x0, dy = y1 - y0;
+    float lenSq = dx*dx + dy*dy;
+    // startX is identical for both vertices of the segment
+    data.insert(data.end(), {x0, y0, lenSq, x0,
+                              x1, y1, lenSq, x0});
+  }
+  vertexCount = (int)(data.size() / 4);
+
+  glBindVertexArray(vao);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
+  glBufferData(GL_ARRAY_BUFFER,
+               (GLsizeiptr)(data.size() * sizeof(float)),
+               data.data(), GL_STATIC_DRAW);
+  constexpr int stride = 4 * sizeof(float);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride, (void*)0);
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(1, 1, GL_FLOAT, GL_FALSE, stride, (void*)(2 * sizeof(float)));
+  glEnableVertexAttribArray(1);
+  glVertexAttribPointer(2, 1, GL_FLOAT, GL_FALSE, stride, (void*)(3 * sizeof(float)));
+  glEnableVertexAttribArray(2);
+  glBindVertexArray(0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void PenUpRenderer::draw() const {
+  if (!valid || vertexCount == 0) return;
+  glUseProgram(program);
+  glUniform1f(uScale,       scale);
+  glUniform1f(uCosR,        cosR);
+  glUniform1f(uSinR,        sinR);
+  glUniform1f(uPanX,        panX);
+  glUniform1f(uPanY,        panY);
+  glUniform1f(uOriginX,     origin.x);
+  glUniform1f(uOriginY,     origin.y);
+  glUniform1f(uCanvasW,     cW);
+  glUniform1f(uCanvasH,     cH);
+  glUniform1f(uDispX,       dispX);
+  glUniform1f(uDispY,       dispY);
+  glUniform1f(uDispW,       dispW);
+  glUniform1f(uDispH,       dispH);
+  glUniform1f(uThresholdSq, thresholdSq);
+  glUniform1f(uCutoffX,     cutoffX);
+  glBindVertexArray(vao);
+  glDrawArrays(GL_LINES, 0, vertexCount);
+  glBindVertexArray(0);
+}
+
+void penUpRenderCallback(const ImDrawList*, const ImDrawCmd *cmd) {
+  auto *r = static_cast<PenUpRenderer*>(cmd->UserCallbackData);
+
+  // Convert ImGui clip rect to GL scissor (framebuffer coords, y-flipped).
+  ImDrawData *dd = ImGui::GetDrawData();
+  float scaleX = dd->FramebufferScale.x, scaleY = dd->FramebufferScale.y;
+  float ox = dd->DisplayPos.x,           oy     = dd->DisplayPos.y;
+  int x1 = (int)((cmd->ClipRect.x - ox) * scaleX);
+  int y1 = (int)((cmd->ClipRect.y - oy) * scaleY);
+  int x2 = (int)((cmd->ClipRect.z - ox) * scaleX);
+  int y2 = (int)((cmd->ClipRect.w - oy) * scaleY);
+  glScissor(x1, r->fbH - y2, x2 - x1, y2 - y1);
+
+  r->draw();
+}
+
+// ── Scene drawing ─────────────────────────────────────────────────────────────
+
+void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
+              const HpglDoc &doc, const DrawParams &p, PenUpRenderer &renderer) {
+  dl->PushClipRect(origin, {origin.x + canvasW, origin.y + canvasH}, true);
+
+  float cosR = cosf(p.rotation);
+  float sinR = sinf(p.rotation);
+
+  // Pen-down strokes (CPU path)
+  for (const auto &stroke : doc.strokes) {
+    if (stroke.points.empty()) continue;
+    int pi = std::max(0, std::min(stroke.pen - 1, 7));
+    ImU32 col = ImGui::ColorConvertFloat4ToU32(p.pens[pi].color);
+    float screen_thick =
+        std::max(1.0f, p.pens[pi].thickness * kHpglUnitsPerMm * p.scale);
+
+    if (stroke.points.size() == 2 && stroke.points[0] == stroke.points[1]) {
+      ImVec2 pt = xfPoint(stroke.points[0].x, stroke.points[0].y, origin,
+                          p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
+      dl->AddCircleFilled(pt, screen_thick * 0.5f, col);
+      continue;
+    }
+
+    for (size_t i = 0; i + 1 < stroke.points.size(); ++i) {
+      ImVec2 p0 = xfPoint(stroke.points[i].x,     stroke.points[i].y,     origin,
+                          p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
+      ImVec2 p1 = xfPoint(stroke.points[i + 1].x, stroke.points[i + 1].y, origin,
+                          p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
+      dl->AddLine(p0, p1, col, screen_thick);
+    }
+  }
+
+  // Pen-up moves — drawn via GPU VBO (one draw call for all segments)
+  if (p.showPenUp && renderer.valid && renderer.vertexCount > 0) {
+    float t  = p.penUpThreshold * kHpglUnitsPerCm;
+    float cx = doc.minX + (p.fixLeftPct / 100.0f) * (doc.maxX - doc.minX);
+    ImVec2 dp = ImGui::GetMainViewport()->Pos;
+    ImVec2 ds = ImGui::GetIO().DisplaySize;
+    renderer.origin      = origin;
+    renderer.cW          = canvasW;
+    renderer.cH          = canvasH;
+    renderer.thresholdSq = t * t;
+    renderer.cutoffX     = cx;
+    renderer.dispX       = dp.x;
+    renderer.dispY       = dp.y;
+    renderer.dispW       = ds.x;
+    renderer.dispH       = ds.y;
+    renderer.scale       = p.scale;
+    renderer.cosR        = cosR;
+    renderer.sinR        = sinR;
+    renderer.panX        = p.panX;
+    renderer.panY        = p.panY;
+    dl->AddCallback(penUpRenderCallback, &renderer);
+    dl->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
+
+    // Draw vertical cutoff line in HPGL space
+    ImVec2 lineTop = xfPoint(cx, doc.minY, origin,
+                             p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
+    ImVec2 lineBot = xfPoint(cx, doc.maxY, origin,
+                             p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
+    dl->AddLine(lineTop, lineBot, IM_COL32(100, 200, 255, 200), 1.5f);
+  }
+
+  dl->PopClipRect();
+}

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -42,6 +42,34 @@ void main() {
 }
 )glsl";
 
+// Vertex shader for pen-down strokes (2-float vertices, same transform as pen-up).
+static const char *kStrokeVertSrc = R"glsl(
+#version 330 core
+layout(location = 0) in vec2 aPos;
+
+uniform float uScale, uCosR, uSinR, uPanX, uPanY;
+uniform float uOriginX, uOriginY, uCanvasW, uCanvasH;
+uniform float uDispX, uDispY, uDispW, uDispH;
+
+void main() {
+    float lx = aPos.x * uScale + uPanX - uCanvasW * 0.5;
+    float ly = aPos.y * uScale + uPanY - uCanvasH * 0.5;
+    float sx = uOriginX + lx * uCosR - ly * uSinR + uCanvasW * 0.5;
+    float sy = uOriginY + lx * uSinR + ly * uCosR + uCanvasH * 0.5;
+    gl_Position = vec4(
+        (sx - uDispX) / uDispW * 2.0 - 1.0,
+        1.0 - (sy - uDispY) / uDispH * 2.0,
+        0.0, 1.0);
+}
+)glsl";
+
+static const char *kStrokeFragSrc = R"glsl(
+#version 330 core
+uniform vec4 uColor;
+out vec4 fragColor;
+void main() { fragColor = uColor; }
+)glsl";
+
 static const char *kPenUpFragSrc = R"glsl(
 #version 330 core
 in float vLenSq;
@@ -227,6 +255,144 @@ void penUpRenderCallback(const ImDrawList*, const ImDrawCmd *cmd) {
   r->draw();
 }
 
+// ── GPU stroke renderer ───────────────────────────────────────────────────────
+
+void StrokeRenderer::init() {
+  auto compile = [](GLenum type, const char *src) -> GLuint {
+    GLuint s = glCreateShader(type);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
+    GLint ok = 0;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+      char log[512];
+      glGetShaderInfoLog(s, sizeof(log), nullptr, log);
+      fprintf(stderr, "StrokeRenderer shader error: %s\n", log);
+    }
+    return s;
+  };
+  GLuint vert = compile(GL_VERTEX_SHADER,   kStrokeVertSrc);
+  GLuint frag = compile(GL_FRAGMENT_SHADER, kStrokeFragSrc);
+  program = glCreateProgram();
+  glAttachShader(program, vert);
+  glAttachShader(program, frag);
+  glLinkProgram(program);
+  {
+    GLint ok = 0;
+    glGetProgramiv(program, GL_LINK_STATUS, &ok);
+    if (!ok) {
+      char log[512];
+      glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+      fprintf(stderr, "StrokeRenderer link error: %s\n", log);
+    }
+  }
+  glDeleteShader(vert);
+  glDeleteShader(frag);
+
+  uScale   = glGetUniformLocation(program, "uScale");
+  uCosR    = glGetUniformLocation(program, "uCosR");
+  uSinR    = glGetUniformLocation(program, "uSinR");
+  uPanX    = glGetUniformLocation(program, "uPanX");
+  uPanY    = glGetUniformLocation(program, "uPanY");
+  uOriginX = glGetUniformLocation(program, "uOriginX");
+  uOriginY = glGetUniformLocation(program, "uOriginY");
+  uCanvasW = glGetUniformLocation(program, "uCanvasW");
+  uCanvasH = glGetUniformLocation(program, "uCanvasH");
+  uDispX   = glGetUniformLocation(program, "uDispX");
+  uDispY   = glGetUniformLocation(program, "uDispY");
+  uDispW   = glGetUniformLocation(program, "uDispW");
+  uDispH   = glGetUniformLocation(program, "uDispH");
+  uColor   = glGetUniformLocation(program, "uColor");
+
+  glGenVertexArrays(1, &vao);
+  glGenBuffers(1, &vbo);
+  valid = true;
+}
+
+void StrokeRenderer::upload(const HpglDoc &doc) {
+  if (!valid) return;
+
+  // Collect line-segment vertex pairs per pen (skip single-point dot strokes).
+  std::vector<float> penData[8];
+  for (const auto &stroke : doc.strokes) {
+    if (stroke.points.size() < 2) continue;
+    if (stroke.points.size() == 2 && stroke.points[0] == stroke.points[1]) continue;
+    int pi = std::max(0, std::min(stroke.pen - 1, 7));
+    for (size_t i = 0; i + 1 < stroke.points.size(); ++i) {
+      penData[pi].push_back(stroke.points[i].x);
+      penData[pi].push_back(stroke.points[i].y);
+      penData[pi].push_back(stroke.points[i + 1].x);
+      penData[pi].push_back(stroke.points[i + 1].y);
+    }
+  }
+
+  // Concatenate into one VBO, record per-pen vertex offset/count.
+  std::vector<float> vboData;
+  int vertOffset = 0;
+  for (int i = 0; i < 8; ++i) {
+    ranges[i].offset = vertOffset;
+    ranges[i].count  = (int)(penData[i].size() / 2); // 2 floats per vertex
+    vboData.insert(vboData.end(), penData[i].begin(), penData[i].end());
+    vertOffset += ranges[i].count;
+  }
+
+  glBindVertexArray(vao);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
+  glBufferData(GL_ARRAY_BUFFER,
+               (GLsizeiptr)(vboData.size() * sizeof(float)),
+               vboData.data(), GL_STATIC_DRAW);
+  constexpr int stride = 2 * sizeof(float);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, stride, (void*)0);
+  glEnableVertexAttribArray(0);
+  glBindVertexArray(0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void StrokeRenderer::draw() const {
+  if (!valid || !pens) return;
+  glUseProgram(program);
+  glUniform1f(uScale,   scale);
+  glUniform1f(uCosR,    cosR);
+  glUniform1f(uSinR,    sinR);
+  glUniform1f(uPanX,    panX);
+  glUniform1f(uPanY,    panY);
+  glUniform1f(uOriginX, origin.x);
+  glUniform1f(uOriginY, origin.y);
+  glUniform1f(uCanvasW, cW);
+  glUniform1f(uCanvasH, cH);
+  glUniform1f(uDispX,   dispX);
+  glUniform1f(uDispY,   dispY);
+  glUniform1f(uDispW,   dispW);
+  glUniform1f(uDispH,   dispH);
+
+  glBindVertexArray(vao);
+  for (int i = 0; i < 8; ++i) {
+    if (ranges[i].count == 0) continue;
+    const auto &c = pens[i].color;
+    glUniform4f(uColor, c.x, c.y, c.z, c.w);
+    float lw = std::max(1.0f, pens[i].thickness * kHpglUnitsPerMm * scale);
+    glLineWidth(lw);
+    glDrawArrays(GL_LINES, ranges[i].offset, ranges[i].count);
+  }
+  glBindVertexArray(0);
+  glLineWidth(1.0f);
+}
+
+void strokeRenderCallback(const ImDrawList*, const ImDrawCmd *cmd) {
+  auto *r = static_cast<StrokeRenderer*>(cmd->UserCallbackData);
+
+  ImDrawData *dd = ImGui::GetDrawData();
+  float scaleX = dd->FramebufferScale.x, scaleY = dd->FramebufferScale.y;
+  float ox = dd->DisplayPos.x,           oy     = dd->DisplayPos.y;
+  int x1 = (int)((cmd->ClipRect.x - ox) * scaleX);
+  int y1 = (int)((cmd->ClipRect.y - oy) * scaleY);
+  int x2 = (int)((cmd->ClipRect.z - ox) * scaleX);
+  int y2 = (int)((cmd->ClipRect.w - oy) * scaleY);
+  glScissor(x1, r->fbH - y2, x2 - x1, y2 - y1);
+
+  r->draw();
+}
+
 // ── Coordinate system overlay ────────────────────────────────────────────────
 
 // Choose a grid step (in HPGL units) that yields 5–20 visible grid lines.
@@ -318,7 +484,8 @@ static void drawCoordinateSystem(ImDrawList *dl, ImVec2 origin,
 // ── Scene drawing ─────────────────────────────────────────────────────────────
 
 void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
-              const HpglDoc &doc, const DrawParams &p, PenUpRenderer &renderer) {
+              const HpglDoc &doc, const DrawParams &p,
+              PenUpRenderer &penUpRenderer, StrokeRenderer &strokeRenderer) {
   dl->PushClipRect(origin, {origin.x + canvasW, origin.y + canvasH}, true);
 
   float cosR = cosf(p.rotation);
@@ -327,69 +494,76 @@ void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
   if (p.showCoords)
     drawCoordinateSystem(dl, origin, canvasW, canvasH, doc, p);
 
-  // Compute visible HPGL AABB by inverse-transforming the 4 canvas corners.
-  // This gives a conservative bounding box used to cull off-screen strokes.
-  float visMinX =  1e30f, visMinY =  1e30f;
-  float visMaxX = -1e30f, visMaxY = -1e30f;
-  for (int ci = 0; ci < 4; ++ci) {
-    float cx = (ci & 1) ? canvasW : 0.f;
-    float cy = (ci & 2) ? canvasH : 0.f;
-    float lx = (cx - canvasW * 0.5f) * cosR + (cy - canvasH * 0.5f) * sinR;
-    float ly = -(cx - canvasW * 0.5f) * sinR + (cy - canvasH * 0.5f) * cosR;
-    float hx = (lx - p.panX + canvasW * 0.5f) / p.scale;
-    float hy = (ly - p.panY + canvasH * 0.5f) / p.scale;
-    visMinX = std::min(visMinX, hx); visMinY = std::min(visMinY, hy);
-    visMaxX = std::max(visMaxX, hx); visMaxY = std::max(visMaxY, hy);
+  // GPU pen-down strokes — one draw call per pen (up to 8 total).
+  if (strokeRenderer.valid) {
+    ImVec2 dp = ImGui::GetMainViewport()->Pos;
+    ImVec2 ds = ImGui::GetIO().DisplaySize;
+    strokeRenderer.origin = origin;
+    strokeRenderer.cW     = canvasW;
+    strokeRenderer.cH     = canvasH;
+    strokeRenderer.dispX  = dp.x;
+    strokeRenderer.dispY  = dp.y;
+    strokeRenderer.dispW  = ds.x;
+    strokeRenderer.dispH  = ds.y;
+    strokeRenderer.scale  = p.scale;
+    strokeRenderer.cosR   = cosR;
+    strokeRenderer.sinR   = sinR;
+    strokeRenderer.panX   = p.panX;
+    strokeRenderer.panY   = p.panY;
+    strokeRenderer.pens   = p.pens;
+    dl->AddCallback(strokeRenderCallback, &strokeRenderer);
+    dl->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
   }
 
-  // Pen-down strokes (CPU path)
-  for (const auto &stroke : doc.strokes) {
-    if (stroke.points.empty()) continue;
-    // Cull strokes entirely outside the visible HPGL area
-    if (stroke.bboxMax.x < visMinX || stroke.bboxMin.x > visMaxX ||
-        stroke.bboxMax.y < visMinY || stroke.bboxMin.y > visMaxY) continue;
-    int pi = std::max(0, std::min(stroke.pen - 1, 7));
-    ImU32 col = ImGui::ColorConvertFloat4ToU32(p.pens[pi].color);
-    float screen_thick =
-        std::max(1.0f, p.pens[pi].thickness * kHpglUnitsPerMm * p.scale);
-
-    if (stroke.points.size() == 2 && stroke.points[0] == stroke.points[1]) {
+  // Dot strokes (single-point pen-8 waypoints) stay on CPU — there are very few.
+  {
+    float visMinX =  1e30f, visMinY =  1e30f;
+    float visMaxX = -1e30f, visMaxY = -1e30f;
+    for (int ci = 0; ci < 4; ++ci) {
+      float cx = (ci & 1) ? canvasW : 0.f;
+      float cy = (ci & 2) ? canvasH : 0.f;
+      float lx = (cx - canvasW * 0.5f) * cosR + (cy - canvasH * 0.5f) * sinR;
+      float ly = -(cx - canvasW * 0.5f) * sinR + (cy - canvasH * 0.5f) * cosR;
+      float hx = (lx - p.panX + canvasW * 0.5f) / p.scale;
+      float hy = (ly - p.panY + canvasH * 0.5f) / p.scale;
+      visMinX = std::min(visMinX, hx); visMinY = std::min(visMinY, hy);
+      visMaxX = std::max(visMaxX, hx); visMaxY = std::max(visMaxY, hy);
+    }
+    for (const auto &stroke : doc.strokes) {
+      if (stroke.points.size() != 2) continue;
+      if (!(stroke.points[0] == stroke.points[1])) continue;
+      if (stroke.bboxMax.x < visMinX || stroke.bboxMin.x > visMaxX ||
+          stroke.bboxMax.y < visMinY || stroke.bboxMin.y > visMaxY) continue;
+      int pi = std::max(0, std::min(stroke.pen - 1, 7));
+      ImU32 col = ImGui::ColorConvertFloat4ToU32(p.pens[pi].color);
+      float screen_thick = std::max(1.0f, p.pens[pi].thickness * kHpglUnitsPerMm * p.scale);
       ImVec2 pt = xfPoint(stroke.points[0].x, stroke.points[0].y, origin,
                           p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
       dl->AddCircleFilled(pt, screen_thick * 0.5f, col);
-      continue;
-    }
-
-    for (size_t i = 0; i + 1 < stroke.points.size(); ++i) {
-      ImVec2 p0 = xfPoint(stroke.points[i].x,     stroke.points[i].y,     origin,
-                          p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
-      ImVec2 p1 = xfPoint(stroke.points[i + 1].x, stroke.points[i + 1].y, origin,
-                          p.panX, p.panY, p.scale, canvasW, canvasH, cosR, sinR);
-      dl->AddLine(p0, p1, col, screen_thick);
     }
   }
 
   // Pen-up moves — drawn via GPU VBO (one draw call for all segments)
-  if (p.showPenUp && renderer.valid && renderer.vertexCount > 0) {
+  if (p.showPenUp && penUpRenderer.valid && penUpRenderer.vertexCount > 0) {
     float t  = p.penUpThreshold * kHpglUnitsPerCm;
     float cx = doc.minX + (p.fixLeftPct / 100.0f) * (doc.maxX - doc.minX);
     ImVec2 dp = ImGui::GetMainViewport()->Pos;
     ImVec2 ds = ImGui::GetIO().DisplaySize;
-    renderer.origin      = origin;
-    renderer.cW          = canvasW;
-    renderer.cH          = canvasH;
-    renderer.thresholdSq = t * t;
-    renderer.cutoffX     = cx;
-    renderer.dispX       = dp.x;
-    renderer.dispY       = dp.y;
-    renderer.dispW       = ds.x;
-    renderer.dispH       = ds.y;
-    renderer.scale       = p.scale;
-    renderer.cosR        = cosR;
-    renderer.sinR        = sinR;
-    renderer.panX        = p.panX;
-    renderer.panY        = p.panY;
-    dl->AddCallback(penUpRenderCallback, &renderer);
+    penUpRenderer.origin      = origin;
+    penUpRenderer.cW          = canvasW;
+    penUpRenderer.cH          = canvasH;
+    penUpRenderer.thresholdSq = t * t;
+    penUpRenderer.cutoffX     = cx;
+    penUpRenderer.dispX       = dp.x;
+    penUpRenderer.dispY       = dp.y;
+    penUpRenderer.dispW       = ds.x;
+    penUpRenderer.dispH       = ds.y;
+    penUpRenderer.scale       = p.scale;
+    penUpRenderer.cosR        = cosR;
+    penUpRenderer.sinR        = sinR;
+    penUpRenderer.panX        = p.panX;
+    penUpRenderer.panY        = p.panY;
+    dl->AddCallback(penUpRenderCallback, &penUpRenderer);
     dl->AddCallback(ImDrawCallback_ResetRenderState, nullptr);
 
     // Draw vertical cutoff line in HPGL space

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -227,6 +227,94 @@ void penUpRenderCallback(const ImDrawList*, const ImDrawCmd *cmd) {
   r->draw();
 }
 
+// ── Coordinate system overlay ────────────────────────────────────────────────
+
+// Choose a grid step (in HPGL units) that yields 5–20 visible grid lines.
+static float pickGridStep(float hpglSpan) {
+  // steps in HPGL units: 1 mm, 5 mm, 1 cm, 2 cm, 5 cm, 10 cm, 20 cm, 50 cm
+  static const float kSteps[] = {40, 200, 400, 800, 2000, 4000, 8000, 20000};
+  for (float s : kSteps)
+    if (hpglSpan / s < 20.f) return s;
+  return kSteps[std::size(kSteps) - 1];
+}
+
+static void drawCoordinateSystem(ImDrawList *dl, ImVec2 origin,
+                                  float cW, float cH,
+                                  const HpglDoc &doc, const DrawParams &p) {
+  const float cosR = cosf(p.rotation);
+  const float sinR = sinf(p.rotation);
+
+  // HPGL viewport (what's currently visible, with a small margin)
+  float invScale = 1.f / p.scale;
+  float visW = cW * invScale;
+  float visH = cH * invScale;
+  float hMinX = (-p.panX) * invScale;
+  float hMinY = (-p.panY) * invScale;
+  float hMaxX = hMinX + visW;
+  float hMaxY = hMinY + visH;
+
+  float stepX = pickGridStep(visW);
+  float stepY = pickGridStep(visH);
+
+  ImU32 gridCol  = IM_COL32( 80, 120, 200,  35);
+  ImU32 axisCol  = IM_COL32( 80, 120, 200,  90);
+  ImU32 labelCol = IM_COL32( 60,  90, 170, 200);
+
+  auto snap = [](float v, float step) { return floorf(v / step) * step; };
+
+  // Vertical grid lines (constant HPGL-X)
+  for (float x = snap(hMinX, stepX); x <= hMaxX; x += stepX) {
+    ImVec2 a = xfPoint(x, hMinY, origin, p.panX, p.panY, p.scale,
+                       cW, cH, cosR, sinR);
+    ImVec2 b = xfPoint(x, hMaxY, origin, p.panX, p.panY, p.scale,
+                       cW, cH, cosR, sinR);
+    ImU32 col = (fabsf(x) < 0.5f) ? axisCol : gridCol;
+    dl->AddLine(a, b, col, 1.f);
+
+    // Label: show value in mm or cm
+    char buf[24];
+    float mm = x / kHpglUnitsPerMm;
+    if (fabsf(mm) < 0.01f) snprintf(buf, sizeof(buf), "0");
+    else if (fabsf(mm) >= 10.f) snprintf(buf, sizeof(buf), "%.0fcm", mm / 10.f);
+    else snprintf(buf, sizeof(buf), "%.0fmm", mm);
+    // Place label near the bottom of the canvas (unrotated: just above bottom edge)
+    ImVec2 lp = xfPoint(x, hMinY + visH * 0.97f, origin, p.panX, p.panY,
+                        p.scale, cW, cH, cosR, sinR);
+    dl->AddText(lp, labelCol, buf);
+  }
+
+  // Horizontal grid lines (constant HPGL-Y)
+  for (float y = snap(hMinY, stepY); y <= hMaxY; y += stepY) {
+    ImVec2 a = xfPoint(hMinX, y, origin, p.panX, p.panY, p.scale,
+                       cW, cH, cosR, sinR);
+    ImVec2 b = xfPoint(hMaxX, y, origin, p.panX, p.panY, p.scale,
+                       cW, cH, cosR, sinR);
+    ImU32 col = (fabsf(y) < 0.5f) ? axisCol : gridCol;
+    dl->AddLine(a, b, col, 1.f);
+
+    char buf[24];
+    float mm = y / kHpglUnitsPerMm;
+    if (fabsf(mm) < 0.01f) snprintf(buf, sizeof(buf), "0");
+    else if (fabsf(mm) >= 10.f) snprintf(buf, sizeof(buf), "%.0fcm", mm / 10.f);
+    else snprintf(buf, sizeof(buf), "%.0fmm", mm);
+    ImVec2 lp = xfPoint(hMinX + visW * 0.01f, y, origin, p.panX, p.panY,
+                        p.scale, cW, cH, cosR, sinR);
+    dl->AddText(lp, labelCol, buf);
+  }
+
+  // Document bounding-box outline
+  if (!doc.empty()) {
+    ImVec2 corners[4] = {
+      xfPoint(doc.minX, doc.minY, origin, p.panX, p.panY, p.scale, cW, cH, cosR, sinR),
+      xfPoint(doc.maxX, doc.minY, origin, p.panX, p.panY, p.scale, cW, cH, cosR, sinR),
+      xfPoint(doc.maxX, doc.maxY, origin, p.panX, p.panY, p.scale, cW, cH, cosR, sinR),
+      xfPoint(doc.minX, doc.maxY, origin, p.panX, p.panY, p.scale, cW, cH, cosR, sinR),
+    };
+    ImU32 boxCol = IM_COL32(80, 120, 200, 120);
+    dl->AddPolyline(corners, 4, boxCol, ImDrawFlags_Closed, 1.f);
+  }
+}
+
 // ── Scene drawing ─────────────────────────────────────────────────────────────
 
 void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
@@ -235,6 +323,9 @@ void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
 
   float cosR = cosf(p.rotation);
   float sinR = sinf(p.rotation);
+
+  if (p.showCoords)
+    drawCoordinateSystem(dl, origin, canvasW, canvasH, doc, p);
 
   // Pen-down strokes (CPU path)
   for (const auto &stroke : doc.strokes) {

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -327,9 +327,27 @@ void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
   if (p.showCoords)
     drawCoordinateSystem(dl, origin, canvasW, canvasH, doc, p);
 
+  // Compute visible HPGL AABB by inverse-transforming the 4 canvas corners.
+  // This gives a conservative bounding box used to cull off-screen strokes.
+  float visMinX =  1e30f, visMinY =  1e30f;
+  float visMaxX = -1e30f, visMaxY = -1e30f;
+  for (int ci = 0; ci < 4; ++ci) {
+    float cx = (ci & 1) ? canvasW : 0.f;
+    float cy = (ci & 2) ? canvasH : 0.f;
+    float lx = (cx - canvasW * 0.5f) * cosR + (cy - canvasH * 0.5f) * sinR;
+    float ly = -(cx - canvasW * 0.5f) * sinR + (cy - canvasH * 0.5f) * cosR;
+    float hx = (lx - p.panX + canvasW * 0.5f) / p.scale;
+    float hy = (ly - p.panY + canvasH * 0.5f) / p.scale;
+    visMinX = std::min(visMinX, hx); visMinY = std::min(visMinY, hy);
+    visMaxX = std::max(visMaxX, hx); visMaxY = std::max(visMaxY, hy);
+  }
+
   // Pen-down strokes (CPU path)
   for (const auto &stroke : doc.strokes) {
     if (stroke.points.empty()) continue;
+    // Cull strokes entirely outside the visible HPGL area
+    if (stroke.bboxMax.x < visMinX || stroke.bboxMin.x > visMaxX ||
+        stroke.bboxMax.y < visMinY || stroke.bboxMin.y > visMaxY) continue;
     int pi = std::max(0, std::min(stroke.pen - 1, 7));
     ImU32 col = ImGui::ColorConvertFloat4ToU32(p.pens[pi].color);
     float screen_thick =

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -256,9 +256,9 @@ static void drawCoordinateSystem(ImDrawList *dl, ImVec2 origin,
   float stepX = pickGridStep(visW);
   float stepY = pickGridStep(visH);
 
-  ImU32 gridCol  = IM_COL32( 80, 120, 200,  35);
-  ImU32 axisCol  = IM_COL32( 80, 120, 200,  90);
-  ImU32 labelCol = IM_COL32( 60,  90, 170, 200);
+  ImU32 gridCol  = IM_COL32( 80, 120, 200,  70);
+  ImU32 axisCol  = IM_COL32( 80, 120, 200, 160);
+  ImU32 labelCol = IM_COL32( 60,  90, 170, 220);
 
   auto snap = [](float v, float step) { return floorf(v / step) * step; };
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -1,0 +1,78 @@
+#pragma once
+
+// GL extension prototypes must be requested before any GL header is included.
+#ifndef GL_GLEXT_PROTOTYPES
+#define GL_GLEXT_PROTOTYPES
+#endif
+#ifndef GLFW_INCLUDE_GLEXT
+#define GLFW_INCLUDE_GLEXT
+#endif
+#include <GLFW/glfw3.h>
+
+#include "imgui.h"
+#include "hpgl_parser.h"
+#include "hpgl_fix.h"
+
+// ── Pen styling ───────────────────────────────────────────────────────────────
+
+struct PenStyle {
+  ImVec4 color     = {0.1f, 0.1f, 0.1f, 1.0f};
+  float  thickness = 0.3f; // mm
+};
+
+// Fill pens[0..7] with default colours.
+void initPenColors(PenStyle pens[8]);
+
+// ── Coordinate helpers ────────────────────────────────────────────────────────
+
+// Undo canvas rotation around its centre: screen-relative → pre-rotation coords.
+ImVec2 unrotateCanvas(float mx, float my, float cW, float cH,
+                      float cosR, float sinR);
+
+// Transform an HPGL point to screen space.
+ImVec2 xfPoint(float hx, float hy, ImVec2 origin,
+               float panX, float panY, float scale,
+               float cW, float cH, float cosR, float sinR);
+
+// ── GPU pen-up renderer ───────────────────────────────────────────────────────
+
+struct PenUpRenderer {
+  GLuint vao = 0, vbo = 0, program = 0;
+  int    vertexCount = 0;
+  bool   valid = false;
+
+  // Per-frame context — set before the ImGui draw callback fires.
+  ImVec2 origin{};
+  float  cW = 0, cH = 0;
+  float  thresholdSq = 0;
+  float  cutoffX = 0;
+  float  dispX = 0, dispY = 0, dispW = 1, dispH = 1;
+  float  scale = 1.0f, cosR = 1.0f, sinR = 0.0f;
+  float  panX  = 0.0f, panY = 0.0f;
+  int    fbH   = 0;
+
+  GLint uScale=-1, uCosR=-1, uSinR=-1, uPanX=-1, uPanY=-1;
+  GLint uOriginX=-1, uOriginY=-1, uCanvasW=-1, uCanvasH=-1;
+  GLint uDispX=-1, uDispY=-1, uDispW=-1, uDispH=-1;
+  GLint uThresholdSq=-1, uCutoffX=-1;
+
+  void init();
+  void upload(const HpglDoc &doc);
+  void draw() const;
+};
+
+// ImGui draw-list callback that issues the GPU pen-up draw call.
+void penUpRenderCallback(const ImDrawList*, const ImDrawCmd *cmd);
+
+// ── Scene drawing ─────────────────────────────────────────────────────────────
+
+struct DrawParams {
+  float panX, panY, scale, rotation;
+  bool  showPenUp;
+  float penUpThreshold; // cm
+  float fixLeftPct;     // percent [0..100]
+  const PenStyle *pens; // pointer to array of 8
+};
+
+void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
+              const HpglDoc &doc, const DrawParams &p, PenUpRenderer &renderer);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -20,8 +20,8 @@ struct PenStyle {
   float  thickness = 0.3f; // mm
 };
 
-// Fill pens[0..7] with default colours.
-void initPenColors(PenStyle pens[8]);
+// Fill pens[0..9] with default colours.
+void initPenColors(PenStyle pens[10]);
 
 // ── Coordinate helpers ────────────────────────────────────────────────────────
 
@@ -71,7 +71,7 @@ struct StrokeRenderer {
   bool   valid = false;
 
   struct PenRange { int offset = 0; int count = 0; };
-  PenRange ranges[8];
+  PenRange ranges[10];
 
   // Per-frame context — set before the ImGui draw callback fires.
   ImVec2 origin{};
@@ -85,7 +85,7 @@ struct StrokeRenderer {
   GLint uScale=-1, uCosR=-1, uSinR=-1, uPanX=-1, uPanY=-1;
   GLint uOriginX=-1, uOriginY=-1, uCanvasW=-1, uCanvasH=-1;
   GLint uDispX=-1, uDispY=-1, uDispW=-1, uDispH=-1;
-  GLint uColor=-1;
+  GLint uColor=-1, uHalfWidth=-1;
 
   void init();
   void upload(const HpglDoc &doc);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -64,6 +64,37 @@ struct PenUpRenderer {
 // ImGui draw-list callback that issues the GPU pen-up draw call.
 void penUpRenderCallback(const ImDrawList*, const ImDrawCmd *cmd);
 
+// ── GPU stroke renderer ───────────────────────────────────────────────────────
+
+struct StrokeRenderer {
+  GLuint vao = 0, vbo = 0, program = 0;
+  bool   valid = false;
+
+  struct PenRange { int offset = 0; int count = 0; };
+  PenRange ranges[8];
+
+  // Per-frame context — set before the ImGui draw callback fires.
+  ImVec2 origin{};
+  float  cW = 0, cH = 0;
+  float  dispX = 0, dispY = 0, dispW = 1, dispH = 1;
+  float  scale = 1.0f, cosR = 1.0f, sinR = 0.0f;
+  float  panX  = 0.0f, panY = 0.0f;
+  int    fbH   = 0;
+  const PenStyle *pens = nullptr;
+
+  GLint uScale=-1, uCosR=-1, uSinR=-1, uPanX=-1, uPanY=-1;
+  GLint uOriginX=-1, uOriginY=-1, uCanvasW=-1, uCanvasH=-1;
+  GLint uDispX=-1, uDispY=-1, uDispW=-1, uDispH=-1;
+  GLint uColor=-1;
+
+  void init();
+  void upload(const HpglDoc &doc);
+  void draw() const;
+};
+
+// ImGui draw-list callback that issues the GPU stroke draw calls.
+void strokeRenderCallback(const ImDrawList*, const ImDrawCmd *cmd);
+
 // ── Scene drawing ─────────────────────────────────────────────────────────────
 
 struct DrawParams {
@@ -76,4 +107,5 @@ struct DrawParams {
 };
 
 void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,
-              const HpglDoc &doc, const DrawParams &p, PenUpRenderer &renderer);
+              const HpglDoc &doc, const DrawParams &p,
+              PenUpRenderer &penUpRenderer, StrokeRenderer &strokeRenderer);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -72,6 +72,7 @@ struct DrawParams {
   float penUpThreshold; // cm
   float fixLeftPct;     // percent [0..100]
   const PenStyle *pens; // pointer to array of 8
+  bool  showCoords = false;
 };
 
 void drawHpgl(ImDrawList *dl, ImVec2 origin, float canvasW, float canvasH,

--- a/src/view_state.cpp
+++ b/src/view_state.cpp
@@ -1,0 +1,27 @@
+#include "view_state.h"
+
+#include <algorithm>
+#include <cmath>
+
+ViewState fitToCanvas(float canvasW, float canvasH, const HpglDoc &doc,
+                      float rotation) {
+  if (doc.empty())
+    return {};
+
+  float docW = doc.maxX - doc.minX;
+  float docH = doc.maxY - doc.minY;
+  if (docW < 1) docW = 1;
+  if (docH < 1) docH = 1;
+
+  float absC = fabsf(cosf(rotation));
+  float absS = fabsf(sinf(rotation));
+  float effW = docW * absC + docH * absS;
+  float effH = docW * absS + docH * absC;
+
+  constexpr float pad = 0.05f;
+  ViewState vs;
+  vs.scale = std::min(canvasW / effW, canvasH / effH) * (1.0f - 2.0f * pad);
+  vs.panX  = canvasW * 0.5f - (doc.minX + docW * 0.5f) * vs.scale;
+  vs.panY  = canvasH * 0.5f - (doc.minY + docH * 0.5f) * vs.scale;
+  return vs;
+}

--- a/src/view_state.h
+++ b/src/view_state.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "hpgl_parser.h"
+
+struct ViewState {
+  float panX  = 0.0f;
+  float panY  = 0.0f;
+  float scale = 1.0f;
+};
+
+// Compute pan/scale that fits doc into a canvas of the given pixel size,
+// accounting for rotation. Returns an identity ViewState if doc is empty.
+ViewState fitToCanvas(float canvasW, float canvasH, const HpglDoc &doc,
+                      float rotation);

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,138 @@
+#include "../src/config.h"
+#include "test_harness.h"
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+// Redirect config to a temp directory for the duration of each test.
+static std::string g_tmpDir;
+
+static void setupTmpConfig() {
+  g_tmpDir = "/tmp/test_config_" + std::to_string(getpid());
+  setenv("XDG_CONFIG_HOME", g_tmpDir.c_str(), 1);
+}
+
+static void teardownTmpConfig() {
+  fs::remove_all(g_tmpDir);
+  unsetenv("XDG_CONFIG_HOME");
+}
+
+// ── shellEscapeSingleQuoted ───────────────────────────────────────────────────
+
+static void test_escape_empty_string() {
+  REQUIRE(shellEscapeSingleQuoted("") == "");
+}
+
+static void test_escape_no_quotes() {
+  REQUIRE(shellEscapeSingleQuoted("hello world") == "hello world");
+}
+
+static void test_escape_single_quote() {
+  // "it's" → "it'\'s"
+  REQUIRE(shellEscapeSingleQuoted("it's") == "it'\\''s");
+}
+
+static void test_escape_multiple_quotes() {
+  // "a'b'c" → "a'\''b'\''c"
+  REQUIRE(shellEscapeSingleQuoted("a'b'c") == "a'\\''b'\\''c");
+}
+
+static void test_escape_only_quotes() {
+  // "''" → "'\\'''\\''", i.e. each ' becomes '\''
+  REQUIRE(shellEscapeSingleQuoted("''") == "'\\'''\\''");
+}
+
+// ── configLoad / configSave ───────────────────────────────────────────────────
+
+static void test_load_missing_key_returns_empty() {
+  setupTmpConfig();
+  REQUIRE(configLoad("nonexistent") == "");
+  teardownTmpConfig();
+}
+
+static void test_save_load_roundtrip() {
+  setupTmpConfig();
+  configSave("my_key", "my_value");
+  REQUIRE(configLoad("my_key") == "my_value");
+  teardownTmpConfig();
+}
+
+static void test_save_overwrites_existing_key() {
+  setupTmpConfig();
+  configSave("key", "first");
+  configSave("key", "second");
+  REQUIRE(configLoad("key") == "second");
+  teardownTmpConfig();
+}
+
+static void test_save_preserves_other_keys() {
+  setupTmpConfig();
+  configSave("alpha", "1");
+  configSave("beta",  "2");
+  configSave("alpha", "updated");
+  REQUIRE(configLoad("alpha") == "updated");
+  REQUIRE(configLoad("beta")  == "2");
+  teardownTmpConfig();
+}
+
+static void test_save_multiple_keys() {
+  setupTmpConfig();
+  configSave("x", "10");
+  configSave("y", "20");
+  configSave("z", "30");
+  REQUIRE(configLoad("x") == "10");
+  REQUIRE(configLoad("y") == "20");
+  REQUIRE(configLoad("z") == "30");
+  teardownTmpConfig();
+}
+
+static void test_value_with_equals_sign() {
+  // Values may contain '=' — only the first '=' is the delimiter.
+  setupTmpConfig();
+  configSave("url", "host=localhost");
+  REQUIRE(configLoad("url") == "host=localhost");
+  teardownTmpConfig();
+}
+
+static void test_load_after_overwrite_returns_single_value() {
+  // After overwriting, the file must contain exactly one entry for the key.
+  setupTmpConfig();
+  configSave("dup", "a");
+  configSave("dup", "b");
+  configSave("dup", "c");
+  REQUIRE(configLoad("dup") == "c");
+  teardownTmpConfig();
+}
+
+// ── configPath ────────────────────────────────────────────────────────────────
+
+static void test_config_path_uses_xdg_config_home() {
+  setenv("XDG_CONFIG_HOME", "/tmp/my_xdg", 1);
+  fs::path p = configPath();
+  unsetenv("XDG_CONFIG_HOME");
+  REQUIRE(p.string().find("/tmp/my_xdg") == 0);
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+int main() {
+  run("escape empty string",             test_escape_empty_string);
+  run("escape no quotes",                test_escape_no_quotes);
+  run("escape single quote",             test_escape_single_quote);
+  run("escape multiple quotes",          test_escape_multiple_quotes);
+  run("escape only quotes",              test_escape_only_quotes);
+  run("load missing key returns empty",  test_load_missing_key_returns_empty);
+  run("save/load roundtrip",             test_save_load_roundtrip);
+  run("save overwrites existing key",    test_save_overwrites_existing_key);
+  run("save preserves other keys",       test_save_preserves_other_keys);
+  run("save multiple keys",              test_save_multiple_keys);
+  run("value with equals sign",          test_value_with_equals_sign);
+  run("overwrite yields single value",   test_load_after_overwrite_returns_single_value);
+  run("configPath uses XDG_CONFIG_HOME", test_config_path_uses_xdg_config_home);
+
+  printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
+  return g_fail > 0 ? 1 : 0;
+}

--- a/tests/test_export_png.cpp
+++ b/tests/test_export_png.cpp
@@ -31,7 +31,7 @@ static std::string tmpPath(const char *suffix) {
 
 static void testEmptyDocReturnsFalse() {
   HpglDoc empty;
-  PenStyle pens[8];
+  PenStyle pens[10];
   for (auto &p : pens) p = defaultPens();
   bool ok = exportPng(empty, pens, tmpPath("_empty.png"));
   REQUIRE(!ok);
@@ -39,7 +39,7 @@ static void testEmptyDocReturnsFalse() {
 
 static void testSimpleDocProducesFile() {
   HpglDoc doc = makeDoc(0, 0, 4000, 4000); // 100mm × 100mm
-  PenStyle pens[8];
+  PenStyle pens[10];
   for (auto &p : pens) p = defaultPens();
   std::string path = tmpPath("_simple.png");
   bool ok = exportPng(doc, pens, path, 200);
@@ -58,7 +58,7 @@ static void testSimpleDocProducesFile() {
 
 static void testUnwritablePathReturnsFalse() {
   HpglDoc doc = makeDoc(0, 0, 4000, 4000);
-  PenStyle pens[8];
+  PenStyle pens[10];
   for (auto &p : pens) p = defaultPens();
   bool ok = exportPng(doc, pens, "/nonexistent_dir/out.png", 200);
   REQUIRE(!ok);
@@ -70,7 +70,7 @@ static void testMultipleStrokes() {
   doc.strokes.push_back(Stroke{{{0,0},{2000,0}}, 1});
   doc.strokes.push_back(Stroke{{{0,2000},{4000,2000}}, 2});
   doc.strokes.push_back(Stroke{{{3000,3000},{3000,3000}}, 3}); // dot stroke
-  PenStyle pens[8];
+  PenStyle pens[10];
   for (auto &p : pens) p = defaultPens();
   std::string path = tmpPath("_multi.png");
   bool ok = exportPng(doc, pens, path, 200);
@@ -81,7 +81,7 @@ static void testMultipleStrokes() {
 static void testWidthDeterminesOutputSize() {
   // Just ensure it doesn't crash with a small width
   HpglDoc doc = makeDoc(0, 0, 4000, 2000);
-  PenStyle pens[8];
+  PenStyle pens[10];
   for (auto &p : pens) p = defaultPens();
   std::string path = tmpPath("_small.png");
   bool ok = exportPng(doc, pens, path, 50);

--- a/tests/test_export_png.cpp
+++ b/tests/test_export_png.cpp
@@ -1,0 +1,100 @@
+#include "../src/export_png.h"
+#include "test_harness.h"
+
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static HpglDoc makeDoc(float x0, float y0, float x1, float y1) {
+  HpglDoc doc;
+  doc.minX = x0; doc.minY = y0;
+  doc.maxX = x1; doc.maxY = y1;
+  doc.strokes.push_back(Stroke{{{x0, y0}, {x1, y1}}, 1});
+  return doc;
+}
+
+static PenStyle defaultPens() {
+  PenStyle p;
+  p.color     = {0.1f, 0.1f, 0.1f, 1.0f};
+  p.thickness = 0.3f;
+  return p;
+}
+
+static std::string tmpPath(const char *suffix) {
+  return std::string("/tmp/test_export_png_") +
+         std::to_string(getpid()) + suffix;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+static void testEmptyDocReturnsFalse() {
+  HpglDoc empty;
+  PenStyle pens[8];
+  for (auto &p : pens) p = defaultPens();
+  bool ok = exportPng(empty, pens, tmpPath("_empty.png"));
+  REQUIRE(!ok);
+}
+
+static void testSimpleDocProducesFile() {
+  HpglDoc doc = makeDoc(0, 0, 4000, 4000); // 100mm × 100mm
+  PenStyle pens[8];
+  for (auto &p : pens) p = defaultPens();
+  std::string path = tmpPath("_simple.png");
+  bool ok = exportPng(doc, pens, path, 200);
+  REQUIRE(ok);
+
+  // File must be non-empty
+  FILE *f = fopen(path.c_str(), "rb");
+  REQUIRE(f != nullptr);
+  fseek(f, 0, SEEK_END);
+  long sz = ftell(f);
+  fclose(f);
+  REQUIRE(sz > 0);
+
+  remove(path.c_str());
+}
+
+static void testUnwritablePathReturnsFalse() {
+  HpglDoc doc = makeDoc(0, 0, 4000, 4000);
+  PenStyle pens[8];
+  for (auto &p : pens) p = defaultPens();
+  bool ok = exportPng(doc, pens, "/nonexistent_dir/out.png", 200);
+  REQUIRE(!ok);
+}
+
+static void testMultipleStrokes() {
+  HpglDoc doc;
+  doc.minX = 0; doc.minY = 0; doc.maxX = 4000; doc.maxY = 4000;
+  doc.strokes.push_back(Stroke{{{0,0},{2000,0}}, 1});
+  doc.strokes.push_back(Stroke{{{0,2000},{4000,2000}}, 2});
+  doc.strokes.push_back(Stroke{{{3000,3000},{3000,3000}}, 3}); // dot stroke
+  PenStyle pens[8];
+  for (auto &p : pens) p = defaultPens();
+  std::string path = tmpPath("_multi.png");
+  bool ok = exportPng(doc, pens, path, 200);
+  REQUIRE(ok);
+  remove(path.c_str());
+}
+
+static void testWidthDeterminesOutputSize() {
+  // Just ensure it doesn't crash with a small width
+  HpglDoc doc = makeDoc(0, 0, 4000, 2000);
+  PenStyle pens[8];
+  for (auto &p : pens) p = defaultPens();
+  std::string path = tmpPath("_small.png");
+  bool ok = exportPng(doc, pens, path, 50);
+  REQUIRE(ok);
+  remove(path.c_str());
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+int main() {
+  run("empty doc returns false",       testEmptyDocReturnsFalse);
+  run("simple doc produces file",      testSimpleDocProducesFile);
+  run("unwritable path returns false", testUnwritablePathReturnsFalse);
+  run("multiple strokes",              testMultipleStrokes);
+  run("small width does not crash",    testWidthDeterminesOutputSize);
+}

--- a/tests/test_harness.h
+++ b/tests/test_harness.h
@@ -1,6 +1,21 @@
 #pragma once
 
 #include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+inline std::string readFile(const std::string &path) {
+  std::ifstream f(path);
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+inline bool endsWith(const std::string &s, const std::string &suffix) {
+  return s.size() >= suffix.size() &&
+         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
 
 static int g_pass = 0, g_fail = 0;
 static const char *g_test = "";
@@ -15,7 +30,7 @@ static const char *g_test = "";
     }                                                                           \
   } while (0)
 
-static void run(const char *name, void (*fn)()) {
+inline void run(const char *name, void (*fn)()) {
   g_test = name;
   fn();
 }

--- a/tests/test_harness.h
+++ b/tests/test_harness.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdio>
+
+static int g_pass = 0, g_fail = 0;
+static const char *g_test = "";
+
+#define REQUIRE(expr)                                                           \
+  do {                                                                          \
+    if (expr) {                                                                 \
+      ++g_pass;                                                                 \
+    } else {                                                                    \
+      ++g_fail;                                                                 \
+      fprintf(stderr, "  FAIL  [%s]  line %d:  %s\n", g_test, __LINE__, #expr);\
+    }                                                                           \
+  } while (0)
+
+static void run(const char *name, void (*fn)()) {
+  g_test = name;
+  fn();
+}

--- a/tests/test_hpgl_fix.cpp
+++ b/tests/test_hpgl_fix.cpp
@@ -246,6 +246,148 @@ static void test_cutoff_boundary_inclusive() {
   REQUIRE(found);
 }
 
+// ── mergeCloseStrokes ────────────────────────────────────────────────────────
+
+static const float *uniformThresholds(float t) {
+  static float buf[10];
+  for (int i = 0; i < 10; ++i) buf[i] = t;
+  return buf;
+}
+
+static void test_merge_same_pen_within_threshold() {
+  // Gap of 10 units, threshold of 15 → strokes must be merged.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{110.f, 0.f}, {200.f, 0.f}}, 1});
+  HpglDoc out = mergeCloseStrokes(doc, uniformThresholds(15.f));
+  REQUIRE(out.strokes.size() == 1);
+}
+
+static void test_merge_same_pen_outside_threshold() {
+  // Gap of 10 units, threshold of 5 → strokes must NOT be merged.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{110.f, 0.f}, {200.f, 0.f}}, 1});
+  HpglDoc out = mergeCloseStrokes(doc, uniformThresholds(5.f));
+  REQUIRE(out.strokes.size() == 2);
+}
+
+static void test_merge_different_pens_not_merged() {
+  // Same gap, both pens within threshold, but different pen numbers → no merge.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{110.f, 0.f}, {200.f, 0.f}}, 2});
+  HpglDoc out = mergeCloseStrokes(doc, uniformThresholds(15.f));
+  REQUIRE(out.strokes.size() == 2);
+}
+
+static void test_merge_chain_three_strokes() {
+  // A→B and B→C both within threshold → all three merged into one stroke.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{110.f, 0.f}, {200.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{210.f, 0.f}, {300.f, 0.f}}, 1});
+  HpglDoc out = mergeCloseStrokes(doc, uniformThresholds(15.f));
+  REQUIRE(out.strokes.size() == 1);
+}
+
+static void test_merge_preserves_all_points() {
+  // Merged stroke contains all points from both input strokes in order.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{110.f, 0.f}, {200.f, 0.f}}, 1});
+  HpglDoc out = mergeCloseStrokes(doc, uniformThresholds(15.f));
+  REQUIRE(out.strokes.size() == 1);
+  REQUIRE(out.strokes[0].points.size() == 4);
+  REQUIRE((out.strokes[0].points[0] == Vec2{  0.f, 0.f}));
+  REQUIRE((out.strokes[0].points[1] == Vec2{100.f, 0.f}));
+  REQUIRE((out.strokes[0].points[2] == Vec2{110.f, 0.f}));
+  REQUIRE((out.strokes[0].points[3] == Vec2{200.f, 0.f}));
+}
+
+static void test_merge_per_pen_threshold() {
+  // Pen 1 has a large threshold, pen 2 has zero → only pen-1 strokes merge.
+  static float buf[10] = {};
+  buf[0] = 50.f; // pen 1 (index 0)
+  buf[1] =  0.f; // pen 2 (index 1)
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{110.f, 0.f}, {200.f, 0.f}}, 1}); // gap 10, pen 1 → merge
+  doc.strokes.push_back(Stroke{{{300.f, 0.f}, {400.f, 0.f}}, 2});
+  doc.strokes.push_back(Stroke{{{310.f, 0.f}, {500.f, 0.f}}, 2}); // gap 10, pen 2 → no merge
+  HpglDoc out = mergeCloseStrokes(doc, buf);
+  REQUIRE(out.strokes.size() == 3); // merged pen-1 pair + 2 separate pen-2 strokes
+}
+
+static void test_merge_empty_strokes_pass_through() {
+  // Empty strokes are not merged with neighbours and are preserved.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{}, 1}); // empty
+  doc.strokes.push_back(Stroke{{{110.f, 0.f}, {200.f, 0.f}}, 1});
+  HpglDoc out = mergeCloseStrokes(doc, uniformThresholds(15.f));
+  // The empty stroke breaks the chain — strokes before and after it are separate.
+  REQUIRE(out.strokes.size() == 3);
+}
+
+static void test_merge_exact_threshold_distance_merges() {
+  // Distance exactly equals threshold (≤ comparison) → must merge.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{115.f, 0.f}, {200.f, 0.f}}, 1}); // gap = 15
+  HpglDoc out = mergeCloseStrokes(doc, uniformThresholds(15.f));
+  REQUIRE(out.strokes.size() == 1);
+}
+
+// ── exportHpgl VS velocity ────────────────────────────────────────────────────
+
+static void test_export_vs_emitted_before_pd_multipoint() {
+  // Multi-point stroke: VS<n>; must appear in the output.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  const std::string tmp = "/tmp/test_export_vs_multi.hpgl";
+  REQUIRE(exportHpgl(doc, tmp, 3));
+  std::string content = readFile(tmp);
+  REQUIRE(content.find("VS3;") != std::string::npos);
+  remove(tmp.c_str());
+}
+
+static void test_export_vs_not_emitted_for_dot() {
+  // Single-point (dot) stroke: VS<n>; must NOT appear.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{50.f, 50.f}}, 1});
+  const std::string tmp = "/tmp/test_export_vs_dot.hpgl";
+  REQUIRE(exportHpgl(doc, tmp, 5));
+  std::string content = readFile(tmp);
+  REQUIRE(content.find("VS5;") == std::string::npos);
+  remove(tmp.c_str());
+}
+
+static void test_export_vs_default_is_1() {
+  // Default vsValue=1: multi-point stroke must get VS1;.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  const std::string tmp = "/tmp/test_export_vs_default.hpgl";
+  REQUIRE(exportHpgl(doc, tmp)); // no vsValue → defaults to 1
+  std::string content = readFile(tmp);
+  REQUIRE(content.find("VS1;") != std::string::npos);
+  remove(tmp.c_str());
+}
+
+static void test_export_vs_each_multipoint_stroke_gets_vs() {
+  // Two multi-point strokes → VS appears twice.
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{200.f, 0.f}, {300.f, 0.f}}, 1});
+  const std::string tmp = "/tmp/test_export_vs_twice.hpgl";
+  REQUIRE(exportHpgl(doc, tmp, 2));
+  std::string content = readFile(tmp);
+  size_t first = content.find("VS2;");
+  REQUIRE(first != std::string::npos);
+  REQUIRE(content.find("VS2;", first + 1) != std::string::npos);
+  remove(tmp.c_str());
+}
+
 // ── exportHpgl edge cases ─────────────────────────────────────────────────────
 
 static void test_export_single_point_stroke_roundtrip() {
@@ -296,6 +438,19 @@ int main(int argc, char **argv) {
   run("cutoff boundary inclusive",            test_cutoff_boundary_inclusive);
   run("export single-point stroke roundtrip", test_export_single_point_stroke_roundtrip);
   run("export unwritable path returns false", test_export_unwritable_path_returns_false);
+
+  run("merge same pen within threshold",      test_merge_same_pen_within_threshold);
+  run("merge same pen outside threshold",     test_merge_same_pen_outside_threshold);
+  run("merge different pens not merged",      test_merge_different_pens_not_merged);
+  run("merge chain three strokes",            test_merge_chain_three_strokes);
+  run("merge preserves all points",           test_merge_preserves_all_points);
+  run("merge per-pen threshold",              test_merge_per_pen_threshold);
+  run("merge empty strokes pass through",     test_merge_empty_strokes_pass_through);
+  run("merge exact threshold distance",       test_merge_exact_threshold_distance_merges);
+  run("export VS emitted for multipoint",     test_export_vs_emitted_before_pd_multipoint);
+  run("export VS not emitted for dot",        test_export_vs_not_emitted_for_dot);
+  run("export VS default is 1",               test_export_vs_default_is_1);
+  run("export VS emitted per stroke",         test_export_vs_each_multipoint_stroke_gets_vs);
 
   printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/tests/test_hpgl_fix.cpp
+++ b/tests/test_hpgl_fix.cpp
@@ -2,25 +2,6 @@
 #include "../src/hpgl_parser.h"
 #include "test_harness.h"
 
-#include <cstring>
-#include <fstream>
-#include <sstream>
-#include <string>
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-static std::string readFile(const std::string &path) {
-  std::ifstream f(path);
-  std::ostringstream ss;
-  ss << f.rdbuf();
-  return ss.str();
-}
-
-static bool endsWith(const std::string &s, const std::string &suffix) {
-  return s.size() >= suffix.size() &&
-         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 static std::string g_dataDir;
@@ -116,8 +97,8 @@ static void test_fix_data_file_has_pen8_and_sp0() {
   REQUIRE(!doc.empty());
 
   // threshold=10 cm, step=2 cm, cutoff=100% of width
-  float threshold = 10.f * 10.f * 40.f;  // 10 cm in HPGL units
-  float step      =  2.f * 10.f * 40.f;
+  float threshold = 10.f * kHpglUnitsPerCm;
+  float step      =  2.f * kHpglUnitsPerCm;
   float cutoff    = doc.maxX;
   HpglDoc fixed   = fixLongPenUps(doc, threshold, step, cutoff);
 
@@ -195,6 +176,15 @@ static void test_stats_empty_strokes_ignored_in_pen_up() {
   REQUIRE(s.penUpMm == 0.0f); // empty stroke breaks the chain
 }
 
+static void test_stats_num_paths_excludes_empty_strokes() {
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}}, 1}); // real
+  doc.strokes.push_back(Stroke{{}, 1});            // empty — must not be counted
+  doc.strokes.push_back(Stroke{{{1.f, 0.f}}, 1}); // real
+  DocStats s = computeDocStats(doc);
+  REQUIRE(s.numPaths == 2); // only the two non-empty strokes
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 int main(int argc, char **argv) {
@@ -211,6 +201,7 @@ int main(int argc, char **argv) {
   run("stats pen-up gap between strokes",     test_stats_pen_up_gap_between_strokes);
   run("stats multiple strokes",               test_stats_multiple_strokes);
   run("stats empty strokes ignored in pen-up",test_stats_empty_strokes_ignored_in_pen_up);
+  run("stats numPaths excludes empty strokes", test_stats_num_paths_excludes_empty_strokes);
 
   printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/tests/test_hpgl_fix.cpp
+++ b/tests/test_hpgl_fix.cpp
@@ -166,14 +166,16 @@ static void test_stats_multiple_strokes() {
   REQUIRE(s.penUpMm   == 10.0f); // gap = 400 units
 }
 
-static void test_stats_empty_strokes_ignored_in_pen_up() {
-  // An empty stroke between two real ones should not produce a pen-up distance
+static void test_stats_empty_strokes_skipped_in_pen_up_chain() {
+  // An empty stroke between two real ones is skipped entirely — it produces
+  // no plotter movement, so the pen-up gap is measured from stroke[0] to
+  // stroke[2] directly: (0,0)→(400,0) = 400 units = 10 mm.
   HpglDoc doc;
   doc.strokes.push_back(Stroke{{{0.f, 0.f}}, 1});
-  doc.strokes.push_back(Stroke{{}, 1});               // empty — no endpoints
+  doc.strokes.push_back(Stroke{{}, 1});               // empty — skipped
   doc.strokes.push_back(Stroke{{{400.f, 0.f}}, 1});
   DocStats s = computeDocStats(doc);
-  REQUIRE(s.penUpMm == 0.0f); // empty stroke breaks the chain
+  REQUIRE(s.penUpMm == 10.0f);
 }
 
 static void test_stats_num_paths_excludes_empty_strokes() {
@@ -183,6 +185,89 @@ static void test_stats_num_paths_excludes_empty_strokes() {
   doc.strokes.push_back(Stroke{{{1.f, 0.f}}, 1}); // real
   DocStats s = computeDocStats(doc);
   REQUIRE(s.numPaths == 2); // only the two non-empty strokes
+}
+
+// ── fixedPath ────────────────────────────────────────────────────────────────
+
+static void test_fixed_path_with_extension() {
+  REQUIRE(fixedPath("foo/bar.hpgl") == "foo/bar_fixed.hpgl");
+}
+
+static void test_fixed_path_no_extension() {
+  REQUIRE(fixedPath("foo/bar") == "foo/bar_fixed.hpgl");
+}
+
+static void test_fixed_path_preserves_non_hpgl_extension() {
+  REQUIRE(fixedPath("/tmp/plot.plt") == "/tmp/plot_fixed.plt");
+}
+
+// ── fixLongPenUps edge cases ──────────────────────────────────────────────────
+
+static void test_single_stroke_doc_returned_unchanged() {
+  // A document with only one stroke has no inter-stroke gaps — must be a no-op.
+  HpglDoc doc;
+  doc.minX = 0; doc.maxX = 100; doc.minY = 0; doc.maxY = 0;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {100.f, 0.f}}, 1});
+  HpglDoc fixed = fixLongPenUps(doc, 400.f, 400.f, doc.maxX);
+  REQUIRE(fixed.strokes.size() == 1);
+  for (auto &s : fixed.strokes) REQUIRE(s.pen != kWaypointPen);
+}
+
+static void test_step_larger_than_dist_inserts_no_waypoints() {
+  // Gap of 800 units, step of 1000 units → floor(800/1000) == 0 waypoints.
+  HpglDoc doc;
+  doc.minX = 0; doc.maxX = 800; doc.minY = 0; doc.maxY = 0;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{800.f, 0.f}}, 1});
+  HpglDoc fixed = fixLongPenUps(doc, 400.f, 1000.f, doc.maxX);
+  for (auto &s : fixed.strokes) REQUIRE(s.pen != kWaypointPen);
+}
+
+static void test_threshold_boundary_equal_does_not_insert() {
+  // dist == thresholdUnits: the guard is strict >, so no waypoints.
+  HpglDoc doc;
+  doc.minX = 0; doc.maxX = 400; doc.minY = 0; doc.maxY = 0;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{400.f, 0.f}}, 1});
+  HpglDoc fixed = fixLongPenUps(doc, 400.f, 100.f, doc.maxX);
+  for (auto &s : fixed.strokes) REQUIRE(s.pen != kWaypointPen);
+}
+
+static void test_cutoff_boundary_inclusive() {
+  // prev.x == cutoffX: the guard is <=, so waypoints ARE inserted.
+  HpglDoc doc;
+  doc.minX = 0; doc.maxX = 1000; doc.minY = 0; doc.maxY = 0;
+  doc.strokes.push_back(Stroke{{{500.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{1500.f, 0.f}}, 1}); // gap = 1000 > threshold
+  float cutoff = 500.f; // exactly at prev.x
+  HpglDoc fixed = fixLongPenUps(doc, 400.f, 400.f, cutoff);
+  bool found = false;
+  for (auto &s : fixed.strokes) if (s.pen == kWaypointPen) found = true;
+  REQUIRE(found);
+}
+
+// ── exportHpgl edge cases ─────────────────────────────────────────────────────
+
+static void test_export_single_point_stroke_roundtrip() {
+  // A single-point stroke should survive export → re-parse as a single point.
+  HpglDoc doc;
+  doc.minX = 50; doc.maxX = 50; doc.minY = 50; doc.maxY = 50;
+  doc.strokes.push_back(Stroke{{{50.f, 50.f}}, 1});
+
+  const std::string tmp = "/tmp/test_single_point.hpgl";
+  REQUIRE(exportHpgl(doc, tmp));
+
+  HpglDoc reloaded = HpglParser{}.parseFile(tmp);
+  REQUIRE(reloaded.strokes.size() == 1);
+  REQUIRE(reloaded.strokes[0].points.size() == 1);
+  REQUIRE((reloaded.strokes[0].points[0] == Vec2{50.f, 50.f}));
+  remove(tmp.c_str());
+}
+
+static void test_export_unwritable_path_returns_false() {
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}}, 1});
+  REQUIRE(!exportHpgl(doc, "/no_such_dir/out.hpgl"));
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -200,8 +285,17 @@ int main(int argc, char **argv) {
   run("stats single stroke pen-down dist",    test_stats_single_stroke_pen_down_dist);
   run("stats pen-up gap between strokes",     test_stats_pen_up_gap_between_strokes);
   run("stats multiple strokes",               test_stats_multiple_strokes);
-  run("stats empty strokes ignored in pen-up",test_stats_empty_strokes_ignored_in_pen_up);
+  run("stats empty strokes skipped in chain", test_stats_empty_strokes_skipped_in_pen_up_chain);
   run("stats numPaths excludes empty strokes", test_stats_num_paths_excludes_empty_strokes);
+  run("fixedPath with extension",              test_fixed_path_with_extension);
+  run("fixedPath no extension",               test_fixed_path_no_extension);
+  run("fixedPath preserves non-hpgl ext",     test_fixed_path_preserves_non_hpgl_extension);
+  run("single-stroke doc unchanged by fix",   test_single_stroke_doc_returned_unchanged);
+  run("step > dist inserts no waypoints",     test_step_larger_than_dist_inserts_no_waypoints);
+  run("threshold boundary equal: no insert",  test_threshold_boundary_equal_does_not_insert);
+  run("cutoff boundary inclusive",            test_cutoff_boundary_inclusive);
+  run("export single-point stroke roundtrip", test_export_single_point_stroke_roundtrip);
+  run("export unwritable path returns false", test_export_unwritable_path_returns_false);
 
   printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/tests/test_hpgl_fix.cpp
+++ b/tests/test_hpgl_fix.cpp
@@ -1,28 +1,11 @@
 #include "../src/hpgl_fix.h"
 #include "../src/hpgl_parser.h"
+#include "test_harness.h"
 
-#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <sstream>
 #include <string>
-
-// ── Minimal test harness ──────────────────────────────────────────────────────
-
-static int g_pass = 0, g_fail = 0;
-static const char *g_test = "";
-
-#define REQUIRE(expr)                                                           \
-  do {                                                                          \
-    if (expr) {                                                                 \
-      ++g_pass;                                                                 \
-    } else {                                                                    \
-      ++g_fail;                                                                 \
-      fprintf(stderr, "  FAIL  [%s]  line %d:  %s\n", g_test, __LINE__, #expr);\
-    }                                                                           \
-  } while (0)
-
-static void run(const char *name, void (*fn)()) { g_test = name; fn(); }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -161,6 +144,57 @@ static void test_fix_data_file_has_pen8_and_sp0() {
   remove(tmp.c_str());
 }
 
+// ── computeDocStats tests ─────────────────────────────────────────────────────
+
+static void test_stats_empty_doc() {
+  HpglDoc doc;
+  DocStats s = computeDocStats(doc);
+  REQUIRE(s.numPaths  == 0);
+  REQUIRE(s.penDownMm == 0.0f);
+  REQUIRE(s.penUpMm   == 0.0f);
+}
+
+static void test_stats_single_stroke_pen_down_dist() {
+  // One stroke: (0,0) → (400,0) — 400 HPGL units = 10 mm
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {400.f, 0.f}}, 1});
+  DocStats s = computeDocStats(doc);
+  REQUIRE(s.numPaths  == 1);
+  REQUIRE(s.penDownMm == 10.0f);
+  REQUIRE(s.penUpMm   == 0.0f);
+}
+
+static void test_stats_pen_up_gap_between_strokes() {
+  // Stroke 1 ends at (0,0); stroke 2 starts at (800,0) — gap = 800 units = 20 mm
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{800.f, 0.f}}, 1});
+  DocStats s = computeDocStats(doc);
+  REQUIRE(s.numPaths == 2);
+  REQUIRE(s.penUpMm  == 20.0f);
+}
+
+static void test_stats_multiple_strokes() {
+  // Two strokes each 400 units long; gap of 400 units between them
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}, {400.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{{800.f, 0.f}, {1200.f, 0.f}}, 1});
+  DocStats s = computeDocStats(doc);
+  REQUIRE(s.numPaths  == 2);
+  REQUIRE(s.penDownMm == 20.0f); // 10 mm + 10 mm
+  REQUIRE(s.penUpMm   == 10.0f); // gap = 400 units
+}
+
+static void test_stats_empty_strokes_ignored_in_pen_up() {
+  // An empty stroke between two real ones should not produce a pen-up distance
+  HpglDoc doc;
+  doc.strokes.push_back(Stroke{{{0.f, 0.f}}, 1});
+  doc.strokes.push_back(Stroke{{}, 1});               // empty — no endpoints
+  doc.strokes.push_back(Stroke{{{400.f, 0.f}}, 1});
+  DocStats s = computeDocStats(doc);
+  REQUIRE(s.penUpMm == 0.0f); // empty stroke breaks the chain
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 int main(int argc, char **argv) {
@@ -172,6 +206,11 @@ int main(int argc, char **argv) {
   run("export ends with SP0",                 test_export_ends_with_sp0);
   run("export roundtrip preserves strokes",   test_export_roundtrip_preserves_strokes);
   run("fix data file has pen8 and SP0",       test_fix_data_file_has_pen8_and_sp0);
+  run("stats empty doc",                      test_stats_empty_doc);
+  run("stats single stroke pen-down dist",    test_stats_single_stroke_pen_down_dist);
+  run("stats pen-up gap between strokes",     test_stats_pen_up_gap_between_strokes);
+  run("stats multiple strokes",               test_stats_multiple_strokes);
+  run("stats empty strokes ignored in pen-up",test_stats_empty_strokes_ignored_in_pen_up);
 
   printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/tests/test_hpgl_parser.cpp
+++ b/tests/test_hpgl_parser.cpp
@@ -200,6 +200,56 @@ static void test_pu_move_does_not_expand_bounds() {
   REQUIRE(doc.maxX == 100 && doc.maxY == 100);
 }
 
+// Odd number of coordinates — trailing value silently dropped
+
+static void test_pd_odd_coords_drops_last() {
+  // PD100,200,300 — three values: pair (100,200) used, lone 300 dropped.
+  auto doc = parse("PD100,200,300;PU;");
+  REQUIRE(doc.strokes.size() == 1);
+  auto &pts = doc.strokes[0].points;
+  // origin anchor + one destination; 300 is silently discarded
+  REQUIRE(pts.size() == 2);
+  REQUIRE((pts[1] == Vec2{100.f, 200.f}));
+}
+
+// Non-numeric token — silently skipped
+
+static void test_pd_bad_token_skipped() {
+  // "1a2" is not a valid float — stof throws, token is dropped.
+  auto doc = parse("PD1a2,300;PU;");
+  // Only one valid value (300), which is also dropped (odd count after bad token).
+  // Regardless of exact result, the parser must not crash.
+  (void)doc; // just confirm it doesn't throw/crash
+  REQUIRE(true);
+}
+
+// SP with no argument — pen unchanged
+
+static void test_sp_no_arg_leaves_pen_unchanged() {
+  auto doc = parse("SP3;SP;PD100,0;PU;");
+  REQUIRE(doc.strokes.size() == 1);
+  REQUIRE(doc.strokes[0].pen == 3); // bare SP; does not reset pen
+}
+
+// SP0 (park) — treated as pen 0, resets cur stroke
+
+static void test_sp0_resets_current_stroke() {
+  // After SP0 a new PD must open a fresh stroke with pen 0.
+  auto doc = parse("SP1;PD100,0;SP0;PD200,0;PU;");
+  REQUIRE(doc.strokes.size() == 2);
+  REQUIRE(doc.strokes[0].pen == 1);
+  REQUIRE(doc.strokes[1].pen == 0);
+}
+
+// Input without terminating semicolon on last command
+
+static void test_no_trailing_semicolon_parsed() {
+  // "PD100,200" with no closing semicolon — params reach end-of-string.
+  auto doc = parse("PD100,200");
+  REQUIRE(doc.strokes.size() == 1);
+  REQUIRE((doc.strokes[0].points.back() == Vec2{100.f, 200.f}));
+}
+
 // ── Entry point ───────────────────────────────────────────────────────────────
 
 int main() {
@@ -227,6 +277,11 @@ int main() {
   run("float coordinates parsed",           test_float_coordinates_parsed);
   run("negative coordinates",               test_negative_coordinates);
   run("PU move does not expand bounds",     test_pu_move_does_not_expand_bounds);
+  run("PD odd coords drops trailing value", test_pd_odd_coords_drops_last);
+  run("PD bad token silently skipped",      test_pd_bad_token_skipped);
+  run("SP no arg leaves pen unchanged",     test_sp_no_arg_leaves_pen_unchanged);
+  run("SP0 resets current stroke",          test_sp0_resets_current_stroke);
+  run("no trailing semicolon parsed",       test_no_trailing_semicolon_parsed);
 
   printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
   return g_fail > 0 ? 1 : 0;

--- a/tests/test_hpgl_parser.cpp
+++ b/tests/test_hpgl_parser.cpp
@@ -1,26 +1,5 @@
 #include "../src/hpgl_parser.h"
-
-#include <cstdio>
-
-// ── Minimal test harness ──────────────────────────────────────────────────────
-
-static int g_pass = 0, g_fail = 0;
-static const char *g_test = "";
-
-#define REQUIRE(expr)                                                           \
-  do {                                                                          \
-    if (expr) {                                                                 \
-      ++g_pass;                                                                 \
-    } else {                                                                    \
-      ++g_fail;                                                                 \
-      fprintf(stderr, "  FAIL  [%s]  line %d:  %s\n", g_test, __LINE__, #expr);\
-    }                                                                           \
-  } while (0)
-
-static void run(const char *name, void (*fn)()) {
-  g_test = name;
-  fn();
-}
+#include "test_harness.h"
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 

--- a/tests/test_renderer.cpp
+++ b/tests/test_renderer.cpp
@@ -136,36 +136,53 @@ static void test_roundtrip_negative_coords() {
 
 // ── initPenColors ─────────────────────────────────────────────────────────────
 
-static void test_init_pen_colors_pen1_is_dark() {
-  PenStyle pens[8];
+static void test_init_pen_colors_pen1_is_red() {
+  PenStyle pens[10];
   initPenColors(pens);
-  // Pen 1 (index 0) should be near-black
-  REQUIRE(pens[0].color.x < 0.2f);
-  REQUIRE(pens[0].color.y < 0.2f);
-  REQUIRE(pens[0].color.z < 0.2f);
+  // Pen 1 (index 0) should be red dominant
+  REQUIRE(pens[0].color.x > 0.5f);
+  REQUIRE(pens[0].color.y < 0.3f);
+  REQUIRE(pens[0].color.z < 0.3f);
   REQUIRE(pens[0].color.w == 1.0f);
 }
 
-static void test_init_pen_colors_pen2_is_red() {
-  PenStyle pens[8];
+static void test_init_pen_colors_pen6_is_dark() {
+  PenStyle pens[10];
   initPenColors(pens);
-  // Pen 2 (index 1): red dominant
-  REQUIRE(pens[1].color.x > 0.5f);
-  REQUIRE(pens[1].color.y < 0.3f);
-  REQUIRE(pens[1].color.z < 0.3f);
+  // Pen 6 (index 5) should be near-black
+  REQUIRE(pens[5].color.x < 0.2f);
+  REQUIRE(pens[5].color.y < 0.2f);
+  REQUIRE(pens[5].color.z < 0.2f);
+}
+
+static void test_init_pen_colors_all_ten_distinct() {
+  PenStyle pens[10];
+  initPenColors(pens);
+  // Verify each pen has the expected dominant channel (the 10 hardcoded colors).
+  // Index: 0=red, 1=green, 2=blue, 3=orange, 4=brown, 5=black, 6=yellow, 7=purple, 8=light-blue, 9=magenta
+  REQUIRE(pens[0].color.x > 0.5f && pens[0].color.y < 0.3f && pens[0].color.z < 0.3f); // red
+  REQUIRE(pens[1].color.y > 0.4f && pens[1].color.x < 0.3f && pens[1].color.z < 0.3f); // green
+  REQUIRE(pens[2].color.z > 0.4f && pens[2].color.x < 0.3f && pens[2].color.y < 0.3f); // blue
+  REQUIRE(pens[3].color.x > 0.5f && pens[3].color.y > 0.3f && pens[3].color.z < 0.3f); // orange (R>G>B)
+  REQUIRE(pens[4].color.x > pens[4].color.z && pens[4].color.y > pens[4].color.z);      // brown (warm)
+  REQUIRE(pens[5].color.x < 0.1f && pens[5].color.y < 0.1f && pens[5].color.z < 0.1f); // black
+  REQUIRE(pens[6].color.x > 0.5f && pens[6].color.y > 0.5f && pens[6].color.z < 0.3f); // yellow
+  REQUIRE(pens[7].color.z > 0.3f && pens[7].color.x > 0.0f && pens[7].color.y < 0.2f); // purple
+  REQUIRE(pens[8].color.z > 0.5f && pens[8].color.x < pens[8].color.z);                 // light blue
+  REQUIRE(pens[9].color.x > 0.5f && pens[9].color.z > 0.5f && pens[9].color.y < 0.3f); // magenta
 }
 
 static void test_init_pen_colors_all_fully_opaque() {
-  PenStyle pens[8];
+  PenStyle pens[10];
   initPenColors(pens);
-  for (int i = 0; i < 8; ++i)
+  for (int i = 0; i < 10; ++i)
     REQUIRE(pens[i].color.w == 1.0f);
 }
 
 static void test_init_pen_colors_default_thickness() {
-  PenStyle pens[8];
+  PenStyle pens[10];
   initPenColors(pens);
-  for (int i = 0; i < 8; ++i)
+  for (int i = 0; i < 10; ++i)
     REQUIRE(pens[i].thickness == 0.3f);
 }
 
@@ -184,8 +201,9 @@ int main() {
   run("roundtrip 45° rotation",           test_roundtrip_45deg_rotation);
   run("roundtrip 90° rotation",           test_roundtrip_90deg_rotation);
   run("roundtrip negative coords",        test_roundtrip_negative_coords);
-  run("initPenColors pen1 is dark",       test_init_pen_colors_pen1_is_dark);
-  run("initPenColors pen2 is red",        test_init_pen_colors_pen2_is_red);
+  run("initPenColors pen1 is red",        test_init_pen_colors_pen1_is_red);
+  run("initPenColors pen6 is dark",       test_init_pen_colors_pen6_is_dark);
+  run("initPenColors all 10 distinct",    test_init_pen_colors_all_ten_distinct);
   run("initPenColors all opaque",         test_init_pen_colors_all_fully_opaque);
   run("initPenColors default thickness",  test_init_pen_colors_default_thickness);
 

--- a/tests/test_renderer.cpp
+++ b/tests/test_renderer.cpp
@@ -1,0 +1,194 @@
+#include "../src/renderer.h"
+#include "test_harness.h"
+
+#include <cmath>
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static bool near(float a, float b, float eps = 1e-3f) {
+  return fabsf(a - b) < eps;
+}
+
+static bool nearVec(ImVec2 a, ImVec2 b, float eps = 1e-3f) {
+  return near(a.x, b.x, eps) && near(a.y, b.y, eps);
+}
+
+// ── unrotateCanvas ────────────────────────────────────────────────────────────
+
+static void test_unrotate_identity_no_rotation() {
+  // cosR=1, sinR=0 → output equals input
+  REQUIRE(nearVec(unrotateCanvas(30.f, 70.f, 200.f, 100.f, 1.f, 0.f),
+                  {30.f, 70.f}));
+}
+
+static void test_unrotate_center_is_invariant() {
+  // The centre of the canvas maps to itself regardless of rotation angle.
+  float cW = 200.f, cH = 100.f;
+  float cx = cW * 0.5f, cy = cH * 0.5f;
+  float angle = static_cast<float>(M_PI) / 3.f; // 60°
+  float cosR = cosf(angle), sinR = sinf(angle);
+  REQUIRE(nearVec(unrotateCanvas(cx, cy, cW, cH, cosR, sinR), {cx, cy}));
+}
+
+static void test_unrotate_90deg() {
+  // 90° rotation, canvas 200×100, point (150, 75):
+  //   u = 150 - 100 = 50,  v = 75 - 50 = 25
+  //   rx = u*cos(90) + v*sin(90) + 100 = 0 + 25 + 100 = 125
+  //   ry = -u*sin(90) + v*cos(90) + 50 = -50 +  0 + 50 =   0
+  float cosR = 0.f, sinR = 1.f; // cos/sin of 90°
+  REQUIRE(nearVec(unrotateCanvas(150.f, 75.f, 200.f, 100.f, cosR, sinR),
+                  {125.f, 0.f}));
+}
+
+static void test_unrotate_180deg() {
+  // 180°: cosR=-1, sinR=0
+  //   u = 30-100=-70, v=70-50=20
+  //   rx = (-70)*(-1) + 20*0 + 100 = 70+100 = 170
+  //   ry = -(-70)*0 + 20*(-1) + 50 = -20+50 = 30
+  float cosR = -1.f, sinR = 0.f;
+  REQUIRE(nearVec(unrotateCanvas(30.f, 70.f, 200.f, 100.f, cosR, sinR),
+                  {170.f, 30.f}));
+}
+
+static void test_unrotate_is_self_inverse_at_0() {
+  // Applying unrotate twice with the same (trivial) rotation gives identity.
+  float cW = 300.f, cH = 200.f;
+  ImVec2 p = {80.f, 140.f};
+  auto once = unrotateCanvas(p.x, p.y, cW, cH, 1.f, 0.f);
+  auto twice = unrotateCanvas(once.x, once.y, cW, cH, 1.f, 0.f);
+  REQUIRE(nearVec(twice, p));
+}
+
+// ── xfPoint ───────────────────────────────────────────────────────────────────
+
+static void test_xf_center_hpgl_maps_to_canvas_center() {
+  // doc 0–100 x 0–100, scale=1.8, pan computed by fitToCanvas (10,10),
+  // no rotation, origin at (0,0), canvas 200×200.
+  // HPGL centre (50,50) should map to canvas centre (100,100).
+  ImVec2 origin{0.f, 0.f};
+  REQUIRE(nearVec(xfPoint(50.f, 50.f, origin, 10.f, 10.f, 1.8f,
+                          200.f, 200.f, 1.f, 0.f),
+                  {100.f, 100.f}));
+}
+
+static void test_xf_scale_doubles_distance_from_center() {
+  // With scale=2 and pan chosen so HPGL origin → canvas origin,
+  // a point 10 HPGL units to the right should be 20 px to the right.
+  // panX = cW*0.5 - 0 = 100, panY = cH*0.5 - 0 = 100 (HPGL origin at canvas centre)
+  // xfPoint(10,0) → sx = 10*2+100-100=20, sy=0+100-100=0 → (0+20+100, 0+0+100)=(120,100)
+  ImVec2 origin{0.f, 0.f};
+  ImVec2 a = xfPoint( 0.f, 0.f, origin, 100.f, 100.f, 2.f, 200.f, 200.f, 1.f, 0.f);
+  ImVec2 b = xfPoint(10.f, 0.f, origin, 100.f, 100.f, 2.f, 200.f, 200.f, 1.f, 0.f);
+  REQUIRE(near(b.x - a.x, 20.f));
+  REQUIRE(near(b.y - a.y,  0.f));
+}
+
+static void test_xf_origin_offset_shifts_result() {
+  // Moving the canvas origin by (50,30) shifts the screen result by the same amount.
+  ImVec2 origin0{  0.f,  0.f};
+  ImVec2 origin1{ 50.f, 30.f};
+  ImVec2 p0 = xfPoint(40.f, 60.f, origin0, 0.f, 0.f, 1.f, 200.f, 200.f, 1.f, 0.f);
+  ImVec2 p1 = xfPoint(40.f, 60.f, origin1, 0.f, 0.f, 1.f, 200.f, 200.f, 1.f, 0.f);
+  REQUIRE(near(p1.x - p0.x, 50.f));
+  REQUIRE(near(p1.y - p0.y, 30.f));
+}
+
+// ── Round-trip: xfPoint then unrotateCanvas recovers the HPGL coords ──────────
+// Algebraically proven: unrotate ∘ xfPoint ≡ identity (up to pan/scale).
+
+static void run_roundtrip(float hx, float hy,
+                          float panX, float panY, float scale,
+                          float cW, float cH, float rotation) {
+  ImVec2 origin{20.f, 15.f};
+  float cosR = cosf(rotation), sinR = sinf(rotation);
+
+  ImVec2 screen = xfPoint(hx, hy, origin,
+                          panX, panY, scale, cW, cH, cosR, sinR);
+  // mouse pos relative to canvas
+  float mx = screen.x - origin.x;
+  float my = screen.y - origin.y;
+  ImVec2 unrot = unrotateCanvas(mx, my, cW, cH, cosR, sinR);
+
+  float recovered_x = (unrot.x - panX) / scale;
+  float recovered_y = (unrot.y - panY) / scale;
+
+  REQUIRE(near(recovered_x, hx));
+  REQUIRE(near(recovered_y, hy));
+}
+
+static void test_roundtrip_no_rotation() {
+  run_roundtrip(123.f, 456.f, 10.f, 10.f, 1.8f, 400.f, 300.f, 0.f);
+}
+
+static void test_roundtrip_45deg_rotation() {
+  run_roundtrip(200.f, 100.f, 50.f, 80.f, 2.0f, 400.f, 400.f,
+                static_cast<float>(M_PI_4));
+}
+
+static void test_roundtrip_90deg_rotation() {
+  run_roundtrip(300.f, 150.f, 20.f, 60.f, 1.5f, 600.f, 400.f,
+                static_cast<float>(M_PI_2));
+}
+
+static void test_roundtrip_negative_coords() {
+  run_roundtrip(-50.f, -80.f, 200.f, 150.f, 1.0f, 300.f, 300.f, 0.f);
+}
+
+// ── initPenColors ─────────────────────────────────────────────────────────────
+
+static void test_init_pen_colors_pen1_is_dark() {
+  PenStyle pens[8];
+  initPenColors(pens);
+  // Pen 1 (index 0) should be near-black
+  REQUIRE(pens[0].color.x < 0.2f);
+  REQUIRE(pens[0].color.y < 0.2f);
+  REQUIRE(pens[0].color.z < 0.2f);
+  REQUIRE(pens[0].color.w == 1.0f);
+}
+
+static void test_init_pen_colors_pen2_is_red() {
+  PenStyle pens[8];
+  initPenColors(pens);
+  // Pen 2 (index 1): red dominant
+  REQUIRE(pens[1].color.x > 0.5f);
+  REQUIRE(pens[1].color.y < 0.3f);
+  REQUIRE(pens[1].color.z < 0.3f);
+}
+
+static void test_init_pen_colors_all_fully_opaque() {
+  PenStyle pens[8];
+  initPenColors(pens);
+  for (int i = 0; i < 8; ++i)
+    REQUIRE(pens[i].color.w == 1.0f);
+}
+
+static void test_init_pen_colors_default_thickness() {
+  PenStyle pens[8];
+  initPenColors(pens);
+  for (int i = 0; i < 8; ++i)
+    REQUIRE(pens[i].thickness == 0.3f);
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+int main() {
+  run("unrotate identity no rotation",    test_unrotate_identity_no_rotation);
+  run("unrotate center is invariant",     test_unrotate_center_is_invariant);
+  run("unrotate 90°",                     test_unrotate_90deg);
+  run("unrotate 180°",                    test_unrotate_180deg);
+  run("unrotate self-inverse at 0°",      test_unrotate_is_self_inverse_at_0);
+  run("xf center HPGL → canvas center",  test_xf_center_hpgl_maps_to_canvas_center);
+  run("xf scale doubles distance",        test_xf_scale_doubles_distance_from_center);
+  run("xf origin offset shifts result",   test_xf_origin_offset_shifts_result);
+  run("roundtrip no rotation",            test_roundtrip_no_rotation);
+  run("roundtrip 45° rotation",           test_roundtrip_45deg_rotation);
+  run("roundtrip 90° rotation",           test_roundtrip_90deg_rotation);
+  run("roundtrip negative coords",        test_roundtrip_negative_coords);
+  run("initPenColors pen1 is dark",       test_init_pen_colors_pen1_is_dark);
+  run("initPenColors pen2 is red",        test_init_pen_colors_pen2_is_red);
+  run("initPenColors all opaque",         test_init_pen_colors_all_fully_opaque);
+  run("initPenColors default thickness",  test_init_pen_colors_default_thickness);
+
+  printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
+  return g_fail > 0 ? 1 : 0;
+}

--- a/tests/test_view_state.cpp
+++ b/tests/test_view_state.cpp
@@ -1,0 +1,143 @@
+#include "../src/view_state.h"
+#include "test_harness.h"
+
+#include <cmath>
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+static HpglDoc makeDoc(float x0, float y0, float x1, float y1) {
+  HpglDoc doc;
+  doc.minX = x0; doc.minY = y0;
+  doc.maxX = x1; doc.maxY = y1;
+  doc.strokes.push_back(Stroke{{{x0, y0}, {x1, y1}}, 1});
+  return doc;
+}
+
+static bool nearlyEqual(float a, float b, float eps = 1e-4f) {
+  return fabsf(a - b) < eps;
+}
+
+// ── Empty doc ─────────────────────────────────────────────────────────────────
+
+static void test_empty_doc_returns_identity() {
+  HpglDoc doc; // no strokes → empty()
+  ViewState vs = fitToCanvas(800.f, 600.f, doc, 0.f);
+  REQUIRE(vs.panX  == 0.f);
+  REQUIRE(vs.panY  == 0.f);
+  REQUIRE(vs.scale == 1.f);
+}
+
+// ── Scale ─────────────────────────────────────────────────────────────────────
+
+static void test_square_doc_in_square_canvas() {
+  // doc 0–100 x 0–100, canvas 200×200, no rotation
+  // effW = effH = 100
+  // scale = min(200/100, 200/100) * (1 - 2*0.05) = 2.0 * 0.9 = 1.8
+  HpglDoc doc = makeDoc(0, 0, 100, 100);
+  ViewState vs = fitToCanvas(200.f, 200.f, doc, 0.f);
+  REQUIRE(nearlyEqual(vs.scale, 1.8f));
+}
+
+static void test_wide_doc_constrained_by_width() {
+  // doc 0–200 x 0–100, canvas 100×200, no rotation
+  // effW=200, effH=100 → scale limited by width: 100/200 * 0.9 = 0.45
+  HpglDoc doc = makeDoc(0, 0, 200, 100);
+  ViewState vs = fitToCanvas(100.f, 200.f, doc, 0.f);
+  REQUIRE(nearlyEqual(vs.scale, 0.45f));
+}
+
+static void test_tall_doc_constrained_by_height() {
+  // doc 0–100 x 0–200, canvas 200×100 → scale limited by height: 100/200 * 0.9 = 0.45
+  HpglDoc doc = makeDoc(0, 0, 100, 200);
+  ViewState vs = fitToCanvas(200.f, 100.f, doc, 0.f);
+  REQUIRE(nearlyEqual(vs.scale, 0.45f));
+}
+
+// ── Pan / centering ───────────────────────────────────────────────────────────
+
+static void test_doc_at_origin_centered_in_canvas() {
+  // doc 0–100 x 0–100, canvas 200×200, scale=1.8
+  // panX = 100 - (0 + 50)*1.8 = 100 - 90 = 10
+  // panY = 100 - (0 + 50)*1.8 = 100 - 90 = 10
+  HpglDoc doc = makeDoc(0, 0, 100, 100);
+  ViewState vs = fitToCanvas(200.f, 200.f, doc, 0.f);
+  REQUIRE(nearlyEqual(vs.panX, 10.f));
+  REQUIRE(nearlyEqual(vs.panY, 10.f));
+}
+
+static void test_doc_offset_from_origin() {
+  // doc 100–200 x 0–100, canvas 200×200
+  // scale = 1.8, docW = 100, mid = 150
+  // panX = 100 - 150 * 1.8 = 100 - 270 = -170
+  HpglDoc doc = makeDoc(100, 0, 200, 100);
+  ViewState vs = fitToCanvas(200.f, 200.f, doc, 0.f);
+  REQUIRE(nearlyEqual(vs.panX, -170.f));
+  REQUIRE(nearlyEqual(vs.panY,   10.f));
+}
+
+// ── Rotation ─────────────────────────────────────────────────────────────────
+
+static void test_rotation_90_swaps_effective_dims() {
+  // doc 0–200 x 0–50 (wide), canvas 300×300
+  // no rotation: effW=200, effH=50 → scale = min(300/200, 300/50) * 0.9 = 1.5 * 0.9 = 1.35
+  // 90° rotation: effW=50, effH=200 → scale = min(300/50, 300/200) * 0.9 = 1.5 * 0.9 = 1.35
+  // (symmetric in this case, but both should be 1.35)
+  HpglDoc doc = makeDoc(0, 0, 200, 50);
+  ViewState vs0 = fitToCanvas(300.f, 300.f, doc, 0.f);
+  ViewState vs90 = fitToCanvas(300.f, 300.f, doc, static_cast<float>(M_PI_2));
+  REQUIRE(nearlyEqual(vs0.scale,  1.35f));
+  REQUIRE(nearlyEqual(vs90.scale, 1.35f));
+}
+
+static void test_rotation_90_wide_canvas() {
+  // doc 0–100 x 0–10 (very wide), 200×200 canvas
+  // no rotation:  effW=100, effH=10 → scale = min(200/100, 200/10)*0.9 = 2*0.9=1.8
+  // 90° rotation: effW=10,  effH=100 → scale = min(200/10, 200/100)*0.9 = 2*0.9=1.8
+  // Still symmetric because canvas is square.
+  HpglDoc doc = makeDoc(0, 0, 100, 10);
+  ViewState vs0  = fitToCanvas(200.f, 200.f, doc, 0.f);
+  ViewState vs90 = fitToCanvas(200.f, 200.f, doc, static_cast<float>(M_PI_2));
+  REQUIRE(nearlyEqual(vs0.scale,  1.8f));
+  REQUIRE(nearlyEqual(vs90.scale, 1.8f));
+}
+
+static void test_rotation_90_non_square_canvas() {
+  // doc 0–100 x 0–100, canvas 400×200
+  // no rotation:  effW=100, effH=100 → scale = min(400/100, 200/100)*0.9 = 2*0.9=1.8
+  // 90° rotation: same effW=100, effH=100 (square doc) → same scale
+  HpglDoc doc = makeDoc(0, 0, 100, 100);
+  ViewState vs0  = fitToCanvas(400.f, 200.f, doc, 0.f);
+  ViewState vs90 = fitToCanvas(400.f, 200.f, doc, static_cast<float>(M_PI_2));
+  REQUIRE(nearlyEqual(vs0.scale,  1.8f));
+  REQUIRE(nearlyEqual(vs90.scale, 1.8f));
+}
+
+// ── Degenerate docs ───────────────────────────────────────────────────────────
+
+static void test_zero_width_doc_uses_min_size() {
+  // A degenerate doc with zero width/height should not divide by zero.
+  HpglDoc doc;
+  doc.minX = 50; doc.maxX = 50; doc.minY = 50; doc.maxY = 50;
+  doc.strokes.push_back(Stroke{{{50.f, 50.f}}, 1});
+  ViewState vs = fitToCanvas(200.f, 200.f, doc, 0.f);
+  // docW/H clamped to 1 → scale = 200/1 * 0.9 = 180
+  REQUIRE(nearlyEqual(vs.scale, 180.f));
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+int main() {
+  run("empty doc returns identity",         test_empty_doc_returns_identity);
+  run("square doc in square canvas",        test_square_doc_in_square_canvas);
+  run("wide doc constrained by width",      test_wide_doc_constrained_by_width);
+  run("tall doc constrained by height",     test_tall_doc_constrained_by_height);
+  run("doc at origin centered in canvas",   test_doc_at_origin_centered_in_canvas);
+  run("doc offset from origin",             test_doc_offset_from_origin);
+  run("rotation 90 swaps effective dims",   test_rotation_90_swaps_effective_dims);
+  run("rotation 90 wide canvas",            test_rotation_90_wide_canvas);
+  run("rotation 90 non-square canvas",      test_rotation_90_non_square_canvas);
+  run("zero-width doc uses min size",       test_zero_width_doc_uses_min_size);
+
+  printf("\n%d/%d passed\n", g_pass, g_pass + g_fail);
+  return g_fail > 0 ? 1 : 0;
+}

--- a/todo.md
+++ b/todo.md
@@ -14,3 +14,10 @@ done:
 
 done:
 - [x] scaling with mouse wheel gets slower the closer i get — zoom factor now proportional to scroll amount via powf(1.1, delta), so fast scrolling zooms faster and trackpads feel smooth
+
+
+done:
+- [x] viewport culling: per-stroke bounding boxes computed at parse time; drawHpgl skips strokes entirely outside the visible HPGL area — O(1) cull per stroke instead of submitting every segment to ImGui
+
+todo:
+-

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,16 @@
+claude should read this file regularly
+
+while i update it with ideas
+
+it should just pick these up and work on them
+
+and update this document too
+
+done:
+- [x] render coordinate system — adaptive grid overlay with mm/cm labels and doc bounding box
+- [x] pen styles: add drop down for 0.3, 0.4, 0.5, 0.6, 0.8, 1.0 pen widths
+- [x] add export image function, that renders the current hpgl as png
+- [x] add multiple hpgls to the same view, to preview various layers
+
+done:
+- [x] scaling with mouse wheel gets slower the closer i get — zoom factor now proportional to scroll amount via powf(1.1, delta), so fast scrolling zooms faster and trackpads feel smooth

--- a/todo.md
+++ b/todo.md
@@ -19,5 +19,8 @@ done:
 done:
 - [x] viewport culling: per-stroke bounding boxes computed at parse time; drawHpgl skips strokes entirely outside the visible HPGL area — O(1) cull per stroke instead of submitting every segment to ImGui
 
+done:
+- [x] GPU stroke renderer: pen-down strokes moved from ImGui CPU draw list (900k AddLine calls/frame) to a VBO with up to 8 glDrawArrays calls per frame — StrokeRenderer in renderer.h/.cpp, uploaded on load/fix, drawn via ImGui draw callback
+
 todo:
 -


### PR DESCRIPTION
…, add tests

- Extract shared test harness to tests/test_harness.h, removing ~20 lines duplicated verbatim between the two test files
- Split header-only hpgl_fix.h into a proper hpgl_fix.h (declarations) + hpgl_fix.cpp (implementation); add fix_lib to meson.build
- Replace Stroke *cur raw pointer in HpglParser with int curIdx=-1 index, eliminating the vector-reallocation pointer invalidation hazard
- Move #include "hpgl_fix.h" from mid-file (line ~479) to top of main.cpp
- Add named constant kWaypointPen=8 in hpgl_fix to replace the magic literal
- Extract computeDocStats() from main.cpp globals into a free function DocStats computeDocStats(const HpglDoc&) in hpgl_fix, with 5 new unit tests
- Fix tooltip coordinate transform to correctly invert rotation (was only inverting pan/scale, giving wrong plotter coords when doc was rotated)
- Add GL_COMPILE_STATUS / GL_LINK_STATUS checks in PenUpRenderer::init() so shader errors are reported instead of silently producing a broken renderer

Tests: 63/63 parser, 32/32 fix (was 18/18 before new tests)